### PR TITLE
Add smart search to product modal, fix PR list delete/edit

### DIFF
--- a/pr-create.php
+++ b/pr-create.php
@@ -490,6 +490,22 @@ if (empty($categories) && $com_id == 0) {
         box-shadow: 0 4px 12px rgba(16, 185, 129, 0.15);
     }
     
+    .product-item.highlighted {
+        border-color: #10b981;
+        background: #d1fae5;
+        box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.3);
+    }
+    
+    .smart-search-input {
+        font-size: 15px !important;
+        padding: 14px 18px !important;
+        font-weight: 500;
+    }
+    
+    .smart-search-input::placeholder {
+        color: #9ca3af;
+    }
+    
     .product-item-name {
         font-weight: 600;
         color: #1f2937;
@@ -539,12 +555,17 @@ var currentRowIndex = null;
 function openProductModal(rowIndex) {
     currentRowIndex = rowIndex;
     document.getElementById('productModal').classList.add('active');
-    document.getElementById('productSearch').value = '';
+    var searchInput = document.getElementById('productSearch');
+    searchInput.value = '';
     filterProducts('');
     var tabs = document.querySelectorAll('.product-modal-tab');
     if (tabs.length > 0) {
         tabs[0].click();
     }
+    // Auto-focus search input after modal animation
+    setTimeout(function() {
+        searchInput.focus();
+    }, 100);
 }
 
 function closeProductModal() {
@@ -579,16 +600,60 @@ function showCategory(catId, btn) {
     });
 }
 
+var highlightedIndex = -1;
+var visibleItems = [];
+
 function filterProducts(search) {
     search = search.toLowerCase();
+    visibleItems = [];
+    highlightedIndex = -1;
+    
     document.querySelectorAll('.product-item').forEach(item => {
         var name = item.querySelector('.product-item-name').textContent.toLowerCase();
+        item.classList.remove('highlighted');
         if (name.includes(search)) {
             item.style.display = 'block';
+            visibleItems.push(item);
         } else {
             item.style.display = 'none';
         }
     });
+    
+    // Auto-highlight first result
+    if (visibleItems.length > 0 && search.length > 0) {
+        highlightedIndex = 0;
+        visibleItems[0].classList.add('highlighted');
+        visibleItems[0].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+}
+
+function handleSearchKeydown(event) {
+    if (visibleItems.length === 0) return;
+    
+    if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (highlightedIndex < visibleItems.length - 1) {
+            if (highlightedIndex >= 0) visibleItems[highlightedIndex].classList.remove('highlighted');
+            highlightedIndex++;
+            visibleItems[highlightedIndex].classList.add('highlighted');
+            visibleItems[highlightedIndex].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
+    } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        if (highlightedIndex > 0) {
+            visibleItems[highlightedIndex].classList.remove('highlighted');
+            highlightedIndex--;
+            visibleItems[highlightedIndex].classList.add('highlighted');
+            visibleItems[highlightedIndex].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
+    } else if (event.key === 'Enter') {
+        event.preventDefault();
+        if (highlightedIndex >= 0 && visibleItems[highlightedIndex]) {
+            visibleItems[highlightedIndex].click();
+        }
+    } else if (event.key === 'Escape') {
+        closeProductModal();
+    }
 }
 
 function sortProducts(order, btn) {
@@ -739,7 +804,7 @@ document.addEventListener('DOMContentLoaded', function() {
         </div>
         
         <div class="product-modal-search">
-            <input type="text" id="productSearch" placeholder="🔍 Search models..." oninput="filterProducts(this.value)">
+            <input type="text" id="productSearch" class="smart-search-input" placeholder="🔍 Type to search models..." oninput="filterProducts(this.value)" onkeydown="handleSearchKeydown(event)" autocomplete="off">
             <div class="product-sort-buttons">
                 <button type="button" class="product-sort-btn" onclick="sortProducts('az', this)">
                     <i class="fa fa-sort-alpha-asc"></i> A-Z

--- a/pr-list.php
+++ b/pr-list.php
@@ -302,20 +302,16 @@
             </thead>
             <tbody>
 <?php
-$query=mysqli_query($db->conn, "select pr.id as id, name,DATE_FORMAT(date,'%d-%m-%Y') as date,cancel, des, name_en, status from pr join company on pr.cus_id=company.id where ".$ven_filter." ".$condition." $search_cond $date_cond order by cancel,id desc");
+// Only show non-cancelled PRs (cancel=0)
+$query=mysqli_query($db->conn, "select pr.id as id, name,DATE_FORMAT(date,'%d-%m-%Y') as date,cancel, des, name_en, status from pr join company on pr.cus_id=company.id where ".$ven_filter." ".$condition." $search_cond $date_cond and cancel='0' order by id desc");
 
  while($data=mysqli_fetch_array($query)){
 echo "<tr><td>PR-".str_pad($data['id'], 6, "0", STR_PAD_LEFT)."</td><td>".htmlspecialchars($data['name_en'])."</td><td>".htmlspecialchars($data['des'])."</td><td>".htmlspecialchars($data['date'])."</td>";
 $var=decodenum($data['status']);
-if($data['cancel']=="1"){
-echo "<td><span class='status-badge cancelled'>".$xml->$var."</span></td><td><a class='action-btn' href='index.php?page=po_make&id=".$data['id']."' title='Edit'><i class=\"fa fa-pencil\"></i></a>";}
-else {
-	echo "<td><span class='status-badge active'>".$xml->$var."</span></td><td><a class='action-btn' href='index.php?page=po_make&id=".$data['id']."' title='Edit'><i class=\"fa fa-pencil\"></i></a><a class='action-btn danger' onClick='return Conf(this)' title='Cancel' href='core-function.php?page=pr_list&id=".$data['id']."&method=D'><i class=\"fa fa-trash\"></i></a>";
-	
-	}
+// All visible PRs are not cancelled, so always show edit and delete buttons
+echo "<td><span class='status-badge active'>".$xml->$var."</span></td><td><a class='action-btn' href='index.php?page=po_make&id=".$data['id']."' title='Edit'><i class=\"fa fa-pencil\"></i></a><a class='action-btn danger' onClick='return Conf(this)' title='Cancel' href='core-function.php?page=pr_list&id=".$data['id']."&method=D'><i class=\"fa fa-trash\"></i></a></td>";
 
-echo "</td>
-</tr>";	
+echo "</tr>";	
 
 	}
 	
@@ -355,21 +351,17 @@ echo "<tr><td>Send out</td><td>".htmlspecialchars($data['tmp'])."</td><td>".html
             </thead>
             <tbody>
 <?php
-$query=mysqli_query($db->conn,"select pr.id as id, name,cancel,DATE_FORMAT(date,'%d-%m-%Y') as date,des, name_en, status from pr join company on pr.ven_id=company.id where ".$cus_filter." ".$condition." $search_cond $date_cond order by cancel,id desc");
+// Only show non-cancelled PRs (cancel=0)
+$query=mysqli_query($db->conn,"select pr.id as id, name,cancel,DATE_FORMAT(date,'%d-%m-%Y') as date,des, name_en, status from pr join company on pr.ven_id=company.id where ".$cus_filter." ".$condition." $search_cond $date_cond and cancel='0' order by id desc");
 
  while($data=mysqli_fetch_array($query)){
 echo "<tr><td>PR-".str_pad($data['id'], 6, "0", STR_PAD_LEFT)."</td><td>".htmlspecialchars($data['name_en'])."</td><td>".htmlspecialchars($data['des'])."</td><td>".htmlspecialchars($data['date'])."</td>";
 
 $val=decodenum($data['status']);
-if($data['cancel']=="1"){
-	
-echo "<td><span class='status-badge cancelled'>".$xml->$val."</span></td><td>";}
-else {
-	echo "<td><span class='status-badge active'>".$xml->$val."</span></td><td><a class='action-btn danger' onClick='return Conf(this)' title='Cancel' href='core-function.php?page=pr_list&id=".$data['id']."&method=D'><i class=\"fa fa-trash\"></i></a></td><td>";
-	
-	}
+// All visible PRs are not cancelled, so always show edit and delete buttons
+echo "<td><span class='status-badge active'>".$xml->$val."</span></td><td><a class='action-btn' href='index.php?page=po_make&id=".$data['id']."' title='Edit'><i class=\"fa fa-pencil\"></i></a><a class='action-btn danger' onClick='return Conf(this)' title='Cancel' href='core-function.php?page=pr_list&id=".$data['id']."&method=D'><i class=\"fa fa-trash\"></i></a></td>";
 
-echo "</td>
+echo "
 </tr>";	
 	
 	}


### PR DESCRIPTION
- Add smart search with auto-focus to product selection modal in pr-make.php and pr-create.php
- Add keyboard navigation (arrow keys, enter, escape) for product selection
- Fix PR delete for admin users (com_id=0) - allow delete without company restriction
- Fix PO delete for admin users with same pattern
- Add proper redirect after PR delete
- Hide cancelled PRs from pr_list (only show cancel=0)
- Add edit and delete icons to both PR Out and PR In tables
- Fix HTML structure issues in pr-list.php