### PR TITLE
fix: bulk select-all checkbox only selecting itself

### DIFF
--- a/js/bulk-select.js
+++ b/js/bulk-select.js
@@ -53,7 +53,13 @@ const BulkSelect = (function () {
   }
 
   function handleSelectAll(e) {
-    rows().forEach(cb => { cb.checked = e.target.checked; handleRowChange(cb); });
+    const checked = e.target.checked;
+    rows().forEach(cb => {
+      cb.checked = checked;
+      checked ? _selected.add(cb.value) : _selected.delete(cb.value);
+      highlightRow(cb);
+    });
+    syncToolbar();
   }
 
   function resetSelection() {


### PR DESCRIPTION
## Bug Fix
`syncHeaderCheckbox()` was called inside `handleRowChange` which was called from the `handleSelectAll` loop. This overwrote `_selectAll.checked = false` mid-loop (because only 1 of N rows was checked at that point), causing `e.target.checked` to flip to `false` — leaving all rows after the first unchecked.

## Fix
`handleSelectAll` now directly updates `_selected` + highlights rows without going through `handleRowChange`, then calls `syncToolbar()` once at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)