### PR TITLE
feat: dynamic page titles across all views

### DIFF
--- a/app/Views/account/profile.php
+++ b/app/Views/account/profile.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Account — Profile';
+
 /**
  * Profile View — MVC version
  * Variables: $user, $message, $messageType

--- a/app/Views/account/settings.php
+++ b/app/Views/account/settings.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Account — Settings';
+
 /**
  * Settings View — MVC version
  * Variables: $user, $message, $messageType

--- a/app/Views/ai/action-log.php
+++ b/app/Views/ai/action-log.php
@@ -1,3 +1,4 @@
+<?php $pageTitle = 'AI Assistant — Action Log'; ?>
 <div class="ai-action-log-page">
 <div class="row">
     <div class="col-lg-12">

--- a/app/Views/ai/chat-history.php
+++ b/app/Views/ai/chat-history.php
@@ -1,3 +1,4 @@
+<?php $pageTitle = 'AI Assistant — Chat History'; ?>
 <div class="ai-chat-history-page">
 <div class="row">
     <div class="col-lg-12">

--- a/app/Views/ai/documentation.php
+++ b/app/Views/ai/documentation.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'AI Assistant — Documentation';
+
 /**
  * AI System Documentation
  * 

--- a/app/Views/ai/schema-browser.php
+++ b/app/Views/ai/schema-browser.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'AI Assistant — Schema Browser';
+
 /** @var array $tables */
 /** @var string $discoveredAt */
 /** @var array|null $cachedSchema */

--- a/app/Views/ai/schema-refresh.php
+++ b/app/Views/ai/schema-refresh.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'AI Assistant — Schema Refresh';
+
 /** @var array|null $cached */
 /** @var bool $autoRefresh */
 ?>

--- a/app/Views/ai/settings.php
+++ b/app/Views/ai/settings.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'AI Assistant — Settings';
+
 /**
  * AI Settings View (rendered inside admin layout)
  * Variables: $settings, $message, $messageType

--- a/app/Views/api/dashboard.php
+++ b/app/Views/api/dashboard.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Dashboard';
+
 /**
  * Sales Channel Dashboard View
  * 

--- a/app/Views/api/docs.php
+++ b/app/Views/api/docs.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Documentation';
+
 /**
  * API Documentation View
  * 

--- a/app/Views/api/invoices.php
+++ b/app/Views/api/invoices.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Invoices';
+
 /**
  * API Invoices View
  *

--- a/app/Views/api/keys.php
+++ b/app/Views/api/keys.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — API Keys';
+
 /**
  * API Keys Management View
  * 

--- a/app/Views/api/order-detail.php
+++ b/app/Views/api/order-detail.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Order Details';
+
 /**
  * Order Detail View
  * 

--- a/app/Views/api/orders.php
+++ b/app/Views/api/orders.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Orders';
+
 /**
  * Channel Orders List View
  * 

--- a/app/Views/api/subscriptions.php
+++ b/app/Views/api/subscriptions.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Subscriptions';
+
 /**
  * API Subscriptions Management (Super Admin)
  * 

--- a/app/Views/api/upgrade.php
+++ b/app/Views/api/upgrade.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Upgrade Plan';
+
 /**
  * Plan Upgrade View
  * 

--- a/app/Views/api/usage-logs.php
+++ b/app/Views/api/usage-logs.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Usage Logs';
+
 /**
  * API Usage Logs View
  * 

--- a/app/Views/api/webhook-deliveries.php
+++ b/app/Views/api/webhook-deliveries.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Webhook Deliveries';
+
 /**
  * Webhook Delivery Log View
  * 

--- a/app/Views/api/webhooks.php
+++ b/app/Views/api/webhooks.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'API — Webhooks';
+
 /**
  * Webhook Management View
  * 

--- a/app/Views/audit/denied.php
+++ b/app/Views/audit/denied.php
@@ -1,2 +1,4 @@
-<?php /** Audit - Access denied */ ?>
+<?php
+$pageTitle = 'Audit Log — Access Denied';
+ /** Audit - Access denied */ ?>
 <div class="alert alert-danger"><i class="fa fa-lock"></i> Access denied. Super Admin privileges required.</div>

--- a/app/Views/audit/list.php
+++ b/app/Views/audit/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Audit Log';
+
 /**
  * Audit Log List View — MVC version
  * Variables: $logs, $actionCounts, $filterUser, $filterAction, $filterEntity, $filterDateFrom, $filterDateTo

--- a/app/Views/billing/list.php
+++ b/app/Views/billing/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Billing';
+
 /**
  * Billing List View — Grouped Billing Notes + Unbilled Invoices
  * Variables: $items, $stats, $total_records, $pagination, $filters, $per_page

--- a/app/Views/billing/make.php
+++ b/app/Views/billing/make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Billing — New';
+
 /**
  * Billing Make View — Legacy Modern Design
  * Variables: $customer, $inv_id, $unbilled, $customers

--- a/app/Views/billing/view.php
+++ b/app/Views/billing/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Billing — Details';
+
 /**
  * Billing Note View — Admin Shell
  * Variables: $billing, $invoices, $vendor, $customer, $amount

--- a/app/Views/brand/form.php
+++ b/app/Views/brand/form.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Brands — New';
+
 /**
  * Brand Form View (standalone)
  * 

--- a/app/Views/brand/list.php
+++ b/app/Views/brand/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Brands';
+
 /**
  * Brand List View
  * 

--- a/app/Views/category/form.php
+++ b/app/Views/category/form.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Categories — New';
+
 /**
  * Category Standalone Form View
  * 

--- a/app/Views/category/list.php
+++ b/app/Views/category/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Categories';
+
 /**
  * Category List View
  * 

--- a/app/Views/company/credits.php
+++ b/app/Views/company/credits.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Companies — Credits';
+
 /**
  * Company Credits View
  * 

--- a/app/Views/company/form.php
+++ b/app/Views/company/form.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Companies — New';
+
 /**
  * Company Form View (Create / Edit)
  * 

--- a/app/Views/company/list.php
+++ b/app/Views/company/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Companies';
+
 /**
  * Company List View
  * 

--- a/app/Views/currency/list.php
+++ b/app/Views/currency/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Currency';
+
 /**
  * Currency Management — Modern UI
  * 

--- a/app/Views/currency/rates.php
+++ b/app/Views/currency/rates.php
@@ -1,3 +1,4 @@
+<?php $pageTitle = 'Currency — Exchange Rates'; ?>
 <div class="content-wrapper">
     <section class="content-header">
         <div class="container-fluid">

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dashboard';
+
 /**
  * Dashboard View — Admin Panel + User Dashboard
  *

--- a/app/Views/delivery/edit.php
+++ b/app/Views/delivery/edit.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Delivery — Edit';
+
 /**
  * Delivery Edit View — Legacy Modern Design
  * Variables: $detail, $products, $id, $mode, $customers

--- a/app/Views/delivery/list.php
+++ b/app/Views/delivery/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Delivery';
+
 /**
  * Delivery List View — Legacy Modern Design
  * Variables: $items_out, $items_in, $sendouts_out, $sendouts_in, $total_out, $total_in, $total_records, $pagination, $filters, $per_page

--- a/app/Views/delivery/make.php
+++ b/app/Views/delivery/make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Delivery — New';
+
 /**
  * Delivery Make View (standalone sendout) — Legacy Modern Design
  * Variables: $customers, $types

--- a/app/Views/delivery/view.php
+++ b/app/Views/delivery/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Delivery — Details';
+
 /**
  * Delivery View (Detail) — Legacy Modern Design
  * Variables: $detail, $products, $id, $mode

--- a/app/Views/devtools/containers.php
+++ b/app/Views/devtools/containers.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Containers';
+
 /**
  * Docker Container Monitor
  * Monitor and manage Docker containers

--- a/app/Views/devtools/debug-php.php
+++ b/app/Views/devtools/debug-php.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Debug Php';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * PHP Debug & Error Log Viewer

--- a/app/Views/devtools/debug-session.php
+++ b/app/Views/devtools/debug-session.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Debug Session';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * Session Debug Tool

--- a/app/Views/devtools/lang-debug.php
+++ b/app/Views/devtools/lang-debug.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Lang Debug';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * Language Debug Tool

--- a/app/Views/devtools/monitoring.php
+++ b/app/Views/devtools/monitoring.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Monitoring';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * Admin Monitoring Dashboard

--- a/app/Views/devtools/roadmap.php
+++ b/app/Views/devtools/roadmap.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Roadmap';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * Developer Roadmap Page

--- a/app/Views/devtools/test-containers.php
+++ b/app/Views/devtools/test-containers.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Test Containers';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * Container Test Tool

--- a/app/Views/devtools/test-crud-ai.php
+++ b/app/Views/devtools/test-crud-ai.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Test Crud Ai';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * AI-Powered CRUD Testing Tool

--- a/app/Views/devtools/test-crud.php
+++ b/app/Views/devtools/test-crud.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Test Crud';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * CRUD Operations Test Script

--- a/app/Views/devtools/test-rbac.php
+++ b/app/Views/devtools/test-rbac.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Dev Tools — Test Rbac';
+
 chdir(__DIR__ . "/../../.."); // Set working directory to project root
 /**
  * RBAC Test Page

--- a/app/Views/expense/categories.php
+++ b/app/Views/expense/categories.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Expenses — Categories';
+
 /**
  * Expense Categories — Management Page
  * 

--- a/app/Views/expense/form.php
+++ b/app/Views/expense/form.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Expenses — New';
+
 /**
  * Expense Form — Create / Edit
  * 

--- a/app/Views/expense/list.php
+++ b/app/Views/expense/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Expenses';
+
 /**
  * Expense List — Modern UI
  * 

--- a/app/Views/expense/project-report.php
+++ b/app/Views/expense/project-report.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Expenses — Project Report';
+
 /**
  * Expense Project Cost Report
  * 

--- a/app/Views/expense/summary.php
+++ b/app/Views/expense/summary.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Expenses — Summary';
+
 /**
  * Expense Summary — Monthly Report & Category Breakdown
  * 

--- a/app/Views/expense/view.php
+++ b/app/Views/expense/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Expenses — Details';
+
 /**
  * Expense Detail View
  * 

--- a/app/Views/export/invoice-payments.php
+++ b/app/Views/export/invoice-payments.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Export — Invoice Payments';
+
 /**
  * Invoice Payments Export - CSV/Excel Export
  * Exports invoice payment tracking data to CSV format

--- a/app/Views/export/report.php
+++ b/app/Views/export/report.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Export — Report';
+
 /**
  * Report Export - CSV/Excel Export
  * Exports report data to CSV format (opens in Excel)

--- a/app/Views/help/dev-summary.php
+++ b/app/Views/help/dev-summary.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Help — Dev Summary';
+
 /**
  * Developer System Summary
  * Technical reference for developers — architecture, database, API, deployment

--- a/app/Views/help/index.php
+++ b/app/Views/help/index.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Help';
+
 /**
  * Help & Support Page
  * Provides FAQs, documentation, and contact information

--- a/app/Views/help/master-data-guide.php
+++ b/app/Views/help/master-data-guide.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Help — Master Data Guide';
+
 /**
  * Master Data Guide
  * Documentation for Category, Brand, Product Type, and Model management

--- a/app/Views/help/user-manual.php
+++ b/app/Views/help/user-manual.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Help — User Manual';
+
 /**
  * User Manual — Complete Guide
  * Step-by-step guide from initial setup to daily operations

--- a/app/Views/invoice/list.php
+++ b/app/Views/invoice/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Invoices';
+
 /**
  * Invoice List View (MVC)
  * Replaces legacy compl-list.php

--- a/app/Views/invoice/quotations.php
+++ b/app/Views/invoice/quotations.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Invoices — Quotations';
+
 /**
  * Quotation List View (MVC)
  * Replaces legacy qa-list.php

--- a/app/Views/invoice/tax-list.php
+++ b/app/Views/invoice/tax-list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Invoices — Tax Invoices';
+
 /**
  * Tax Invoice List View (MVC)
  * Replaces legacy compl-list2.php

--- a/app/Views/invoice/view.php
+++ b/app/Views/invoice/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Invoices — Details';
+
 /**
  * Invoice Detail View (MVC)
  * Replaces legacy compl-view.php

--- a/app/Views/journal/accounts.php
+++ b/app/Views/journal/accounts.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Journal — Chart of Accounts';
+
 /**
  * Chart of Accounts — Modern UI
  * 

--- a/app/Views/journal/form.php
+++ b/app/Views/journal/form.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Journal — New';
+
 /**
  * Journal Voucher Create/Edit Form — Modern UI
  * 

--- a/app/Views/journal/list.php
+++ b/app/Views/journal/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Journal';
+
 /**
  * Journal Voucher List — Modern UI
  * 

--- a/app/Views/journal/trial-balance.php
+++ b/app/Views/journal/trial-balance.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Journal — Trial Balance';
+
 /**
  * Trial Balance Report — Modern UI
  * 

--- a/app/Views/journal/view.php
+++ b/app/Views/journal/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Journal — Details';
+
 /**
  * Journal Voucher Detail View — Modern UI
  * 

--- a/app/Views/layouts/head.php
+++ b/app/Views/layouts/head.php
@@ -1,7 +1,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
 
-    <title>CMS</title>
+    <title><?= isset($pageTitle) ? htmlspecialchars($pageTitle) . ' — iACC' : 'iACC' ?></title>
 
     <!-- Core CSS - Include with every page -->
     <?php 

--- a/app/Views/line-oa/auto-replies.php
+++ b/app/Views/line-oa/auto-replies.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Auto Replies';
+
 /**
  * LINE OA Auto-Reply Rules
  */

--- a/app/Views/line-oa/dashboard.php
+++ b/app/Views/line-oa/dashboard.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Dashboard';
+
 /**
  * LINE OA Dashboard — redesigned to match API Sales Channel dashboard style
  * Uses master-data.css design system (stat-card, stats-row, master-data-container)

--- a/app/Views/line-oa/messages.php
+++ b/app/Views/line-oa/messages.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Messages';
+
 /**
  * LINE OA Messages Log
  */

--- a/app/Views/line-oa/order-detail.php
+++ b/app/Views/line-oa/order-detail.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Order Details';
+
 /**
  * LINE OA Order Detail
  */

--- a/app/Views/line-oa/orders.php
+++ b/app/Views/line-oa/orders.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Orders';
+
 /**
  * LINE OA Orders List
  */

--- a/app/Views/line-oa/send-message.php
+++ b/app/Views/line-oa/send-message.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Send Message';
+
 /**
  * LINE OA Send Message
  */

--- a/app/Views/line-oa/settings.php
+++ b/app/Views/line-oa/settings.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Settings';
+
 /**
  * LINE OA Settings
  * Configure LINE channel credentials and behavior

--- a/app/Views/line-oa/users.php
+++ b/app/Views/line-oa/users.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Users';
+
 /**
  * LINE OA Users List
  */

--- a/app/Views/line-oa/webhook-log.php
+++ b/app/Views/line-oa/webhook-log.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'LINE OA — Webhook Log';
+
 /**
  * LINE OA Webhook Event Log
  */

--- a/app/Views/model/list.php
+++ b/app/Views/model/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Models';
+
 /**
  * Model List View
  * 

--- a/app/Views/module-manager/list.php
+++ b/app/Views/module-manager/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Module Manager';
+
 /**
  * Module Manager - List View (Card-Based Layout)
  * Variables: $companies, $stats, $totalCompanies, $modules, $plans, $search, $xml

--- a/app/Views/payment-gateway/config.php
+++ b/app/Views/payment-gateway/config.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Payment Gateway — Configuration';
+
 /**
  * Payment Gateway Configuration View
  * Variables: $gateways, $gatewayConfigs, $gatewayFields, $message, $messageType, $xml

--- a/app/Views/payment-gateway/promptpay.php
+++ b/app/Views/payment-gateway/promptpay.php
@@ -1,3 +1,4 @@
+<?php $pageTitle = 'Payment Gateway — PromptPay'; ?>
 <div class="content-wrapper">
     <section class="content-header">
         <div class="container-fluid">

--- a/app/Views/payment-method/form.php
+++ b/app/Views/payment-method/form.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Payment Methods — New';
+
 /**
  * Payment Method Form View
  * 

--- a/app/Views/payment-method/list.php
+++ b/app/Views/payment-method/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Payment Methods';
+
 /**
  * Payment Method List View
  * 

--- a/app/Views/payment/list.php
+++ b/app/Views/payment/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Payments';
+
 /**
  * Payment List View — Legacy Modern Design (inline add/edit)
  * Variables: $items, $total, $search, $edit_id, $edit_data

--- a/app/Views/po/delivery.php
+++ b/app/Views/po/delivery.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Orders — Delivery';
+
 /**
  * PO Delivery View — Legacy Modern Design
  * Variables: $po, $id, $action, $products

--- a/app/Views/po/edit.php
+++ b/app/Views/po/edit.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Orders — Edit';
+
 /**
  * PO Edit View — Legacy Modern Design
  * Variables: $po, $id, $products, $types, $models, $brands, $companies

--- a/app/Views/po/list.php
+++ b/app/Views/po/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Orders';
+
 /**
  * PO List View — Legacy Modern Design
  * Variables: $items_out, $items_in, $total_out, $total_in, $total_records, $pagination, $filters, $per_page, $query_params

--- a/app/Views/po/make.php
+++ b/app/Views/po/make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Orders — New';
+
 /**
  * PO Make View — Modern UX/UI (from legacy po-make.php)
  * Variables: $pr, $id, $types, $models, $models_by_type, $brands, $companies, $vendor, $tmp_products, $credit

--- a/app/Views/po/view.php
+++ b/app/Views/po/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Orders — Details';
+
 /**
  * PO View (Detail) — Legacy Modern Design
  * Variables: $po, $id, $products, $has_labour, $payment_methods

--- a/app/Views/pr/create.php
+++ b/app/Views/pr/create.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Requests — New';
+
 /**
  * PR Create View — Full product selection with modal
  * Variables from controller: $customers, $categories (with nested types+prices), $com_id

--- a/app/Views/pr/list.php
+++ b/app/Views/pr/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Requests';
+
 /**
  * PR List View — Modern UX/UI (from legacy pr-list.php)
  * Variables: $items_out, $items_in, $total_out, $total_in, $total_records, $pagination, $filters, $per_page, $query_params

--- a/app/Views/pr/view.php
+++ b/app/Views/pr/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Purchase Requests — Details';
+
 /**
  * Purchase Request View — Legacy Modern Design
  * Variables: $pr, $products, $id

--- a/app/Views/quick-create/index.php
+++ b/app/Views/quick-create/index.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Quick Create';
+
 /**
  * Quick Create — Entry Point Selector
  * Choose: Quotation, Invoice, or Tax Invoice

--- a/app/Views/quick-create/invoice.php
+++ b/app/Views/quick-create/invoice.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Quick Create — New Invoice';
+
 /**
  * Quick Create — Invoice Entry Form (Entry Point B)
  * Auto-creates: PR + PO + Delivery (upstream)

--- a/app/Views/quick-create/quotation.php
+++ b/app/Views/quick-create/quotation.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Quick Create — New Quotation';
+
 /**
  * Quick Create — Quotation Entry Form (Entry Point A)
  * Auto-creates: PR (upstream)

--- a/app/Views/quick-create/tax-invoice.php
+++ b/app/Views/quick-create/tax-invoice.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Quick Create — New Tax Invoice';
+
 /**
  * Quick Create — Tax Invoice Entry Form (Entry Point C)
  * Auto-creates: PR + PO + Delivery + Invoice (upstream)

--- a/app/Views/receipt/list.php
+++ b/app/Views/receipt/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Receipts';
+
 /**
  * Receipt List View — Legacy Modern Design
  * Variables: $items, $stats, $total_records, $pagination, $filters, $per_page

--- a/app/Views/receipt/make.php
+++ b/app/Views/receipt/make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Receipts — New';
+
 /**
  * Receipt Make/Edit View — Legacy Modern Design
  * Variables: $receipt, $products, $id, $types, $quotations, $invoices

--- a/app/Views/receipt/view.php
+++ b/app/Views/receipt/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Receipts — Details';
+
 /**
  * Receipt View — Legacy Modern Design
  * Variables: $receipt, $products, $id

--- a/app/Views/report/ar-aging.php
+++ b/app/Views/report/ar-aging.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Reports — AR Aging';
+
 /**
  * AR Aging Report — Accounts Receivable Aging
  * Variables: $buckets, $grand_total, $com_id

--- a/app/Views/report/hub.php
+++ b/app/Views/report/hub.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Reports — Reports';
+
 /**
  * Reports Hub — Central reports navigation
  * Variables: $com_id, $user_level

--- a/app/Views/report/invoice-payments.php
+++ b/app/Views/report/invoice-payments.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Reports — Invoice Payments';
+
 /**
  * Invoice Payments View — MVC version
  * Variables: $summary, $rows, $pagination, $status, $search, $queryParams

--- a/app/Views/report/summary.php
+++ b/app/Views/report/summary.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Reports — Summary';
+
 /**
  * Business Summary Report View — MVC version
  * Variables: $reportData, $totals, $period, $periodLabel, $sortBy, $sortDir, $noCompany

--- a/app/Views/slip-review/index.php
+++ b/app/Views/slip-review/index.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Slip Review';
+
 /**
  * Slip Review — Admin PromptPay Payment Review
  * 

--- a/app/Views/tax/dashboard.php
+++ b/app/Views/tax/dashboard.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tax — Dashboard';
+
 /**
  * Tax Report Dashboard — Annual VAT Summary
  * 

--- a/app/Views/tax/pp30.php
+++ b/app/Views/tax/pp30.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tax — PP30 Report';
+
 /**
  * PP30 (ภ.พ.30) — Monthly VAT Return — Modern UI
  * 

--- a/app/Views/tax/wht.php
+++ b/app/Views/tax/wht.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tax — WHT Report';
+
 /**
  * WHT Report (ภ.ง.ด.3 / ภ.ง.ด.53) — Modern UI
  * 

--- a/app/Views/tour-agent/contract-make.php
+++ b/app/Views/tour-agent/contract-make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Agents — New Contract';
+
 /**
  * Agent Contract — Create / Edit Form
  * 

--- a/app/Views/tour-agent/contracts.php
+++ b/app/Views/tour-agent/contracts.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Agents — Contracts';
+
 /**
  * Agent Contracts — List View
  * 

--- a/app/Views/tour-agent/list.php
+++ b/app/Views/tour-agent/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Agents';
+
 /**
  * Tour Agent Profiles — List Page
  * 

--- a/app/Views/tour-agent/make.php
+++ b/app/Views/tour-agent/make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Agents — New';
+
 /**
  * Tour Agent Profile — Create / Edit Form
  * 

--- a/app/Views/tour-booking/list.php
+++ b/app/Views/tour-booking/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Bookings';
+
 /**
  * Tour Bookings — List Page
  *

--- a/app/Views/tour-booking/payments.php
+++ b/app/Views/tour-booking/payments.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Bookings — Payments';
+
 /**
  * Tour Booking — Payments tab / page
  *

--- a/app/Views/tour-booking/promptpay.php
+++ b/app/Views/tour-booking/promptpay.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Bookings — PromptPay';
+
 /**
  * Tour Booking — PromptPay QR Payment Page
  *

--- a/app/Views/tour-booking/view.php
+++ b/app/Views/tour-booking/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Bookings — Details';
+
 /**
  * Tour Booking — Detail View (read-only)
  *

--- a/app/Views/tour-location/list.php
+++ b/app/Views/tour-location/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Locations';
+
 /**
  * Tour Locations — List Page
  * 

--- a/app/Views/tour-report/checkin-print.php
+++ b/app/Views/tour-report/checkin-print.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Reports — Check-in Sheet';
+
 /**
  * Tour Report — Customer Check-in List PDF (landscape A4)
  * Standalone mPDF view

--- a/app/Views/tour-report/index.php
+++ b/app/Views/tour-report/index.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Reports';
+
 /**
  * Tour Report — Filter Hub Page
  *

--- a/app/Views/tour-report/pickup-print.php
+++ b/app/Views/tour-report/pickup-print.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Tour Reports — Pickup Sheet';
+
 /**
  * Tour Report — Pickup Report for Driver PDF (portrait A4)
  * Standalone mPDF view

--- a/app/Views/type/list.php
+++ b/app/Views/type/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Types';
+
 /**
  * Type (Product) List View
  * 

--- a/app/Views/user/list.php
+++ b/app/Views/user/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Users';
+
 /**
  * User Management List View — MVC version
  * Variables: $usersByRole, $companies, $search, $roleFilter, $companyFilter, $message, $messageType

--- a/app/Views/voucher/list.php
+++ b/app/Views/voucher/list.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Vouchers';
+
 /**
  * Voucher List View — Legacy Modern Design
  * Variables: $items, $stats, $total_records, $pagination, $filters, $per_page

--- a/app/Views/voucher/make.php
+++ b/app/Views/voucher/make.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Vouchers — New';
+
 /**
  * Voucher Make/Edit View — Legacy Modern Design
  * Variables: $voucher, $products, $types, $models, $models_by_type, $brands, $vendor_brands, $payment_methods, $id

--- a/app/Views/voucher/view.php
+++ b/app/Views/voucher/view.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = 'Vouchers — Details';
+
 /**
  * Voucher View — Legacy Modern Design
  * Variables: $voucher, $products, $id

--- a/scripts/add-page-titles.php
+++ b/scripts/add-page-titles.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Script: Add $pageTitle to all module views
+ * Run: php scripts/add-page-titles.php
+ */
+
+// Module name mapping (folder → readable name)
+$moduleNames = [
+    'tour-booking'    => 'Tour Bookings',
+    'tour-agent'      => 'Tour Agents',
+    'tour-location'   => 'Tour Locations',
+    'tour-report'     => 'Tour Reports',
+    'payment-method'  => 'Payment Methods',
+    'payment-gateway' => 'Payment Gateway',
+    'payment'         => 'Payments',
+    'quick-create'    => 'Quick Create',
+    'line-oa'         => 'LINE OA',
+    'module-manager'  => 'Module Manager',
+    'slip-review'     => 'Slip Review',
+    'billing'         => 'Billing',
+    'receipt'         => 'Receipts',
+    'invoice'         => 'Invoices',
+    'voucher'         => 'Vouchers',
+    'delivery'        => 'Delivery',
+    'expense'         => 'Expenses',
+    'journal'         => 'Journal',
+    'report'          => 'Reports',
+    'tax'             => 'Tax',
+    'po'              => 'Purchase Orders',
+    'pr'              => 'Purchase Requests',
+    'audit'           => 'Audit Log',
+    'dashboard'       => 'Dashboard',
+    'user'            => 'Users',
+    'company'         => 'Companies',
+    'brand'           => 'Brands',
+    'category'        => 'Categories',
+    'type'            => 'Types',
+    'model'           => 'Models',
+    'currency'        => 'Currency',
+    'account'         => 'Account',
+    'api'             => 'API',
+    'ai'              => 'AI Assistant',
+    'devtools'        => 'Dev Tools',
+    'help'            => 'Help',
+    'export'          => 'Export',
+];
+
+// File name mapping (filename without .php → suffix)
+$fileTitles = [
+    'list'           => '',           // "Tour Bookings"
+    'index'          => '',           // "Dashboard"
+    'dashboard'      => 'Dashboard',
+    'make'           => 'New',        // "New Tour Booking"
+    'form'           => 'New',
+    'create'         => 'New',
+    'view'           => 'Details',
+    'edit'           => 'Edit',
+    'print'          => 'Print',
+    'payments'       => 'Payments',
+    'contracts'      => 'Contracts',
+    'contract-make'  => 'New Contract',
+    'settings'       => 'Settings',
+    'profile'        => 'Profile',
+    'rates'          => 'Exchange Rates',
+    'summary'        => 'Summary',
+    'categories'     => 'Categories',
+    'report'         => 'Report',
+    'hub'            => 'Reports',
+    'accounts'       => 'Chart of Accounts',
+    'trial-balance'  => 'Trial Balance',
+    'ar-aging'       => 'AR Aging',
+    'pp30'           => 'PP30 Report',
+    'wht'            => 'WHT Report',
+    'config'         => 'Configuration',
+    'promptpay'      => 'PromptPay',
+    'messages'       => 'Messages',
+    'auto-replies'   => 'Auto Replies',
+    'webhook-log'    => 'Webhook Log',
+    'send-message'   => 'Send Message',
+    'users'          => 'Users',
+    'orders'         => 'Orders',
+    'order-detail'   => 'Order Details',
+    'subscriptions'  => 'Subscriptions',
+    'keys'           => 'API Keys',
+    'webhooks'       => 'Webhooks',
+    'webhook-deliveries' => 'Webhook Deliveries',
+    'docs'           => 'Documentation',
+    'usage-logs'     => 'Usage Logs',
+    'upgrade'        => 'Upgrade Plan',
+    'invoices'       => 'Invoices',
+    'tax-list'       => 'Tax Invoices',
+    'quotations'     => 'Quotations',
+    'project-report' => 'Project Report',
+    'action-log'     => 'Action Log',
+    'chat-history'   => 'Chat History',
+    'documentation'  => 'Documentation',
+    'schema-browser' => 'Schema Browser',
+    'schema-refresh' => 'Schema Refresh',
+    'denied'         => 'Access Denied',
+    'credits'        => 'Credits',
+    'checkin-print'  => 'Check-in Sheet',
+    'pickup-print'   => 'Pickup Sheet',
+    'dev-summary'    => 'Dev Summary',
+    'user-manual'    => 'User Manual',
+    'master-data-guide' => 'Master Data Guide',
+    'monitoring'     => 'Monitoring',
+    'roadmap'        => 'Roadmap',
+    'invoice'        => 'New Invoice',
+    'quotation'      => 'New Quotation',
+    'tax-invoice'    => 'New Tax Invoice',
+    'delivery'       => 'Delivery',
+];
+
+// Files to skip (print/pdf pages that have their own <title>, or partials)
+$skip = ['print', '_nav', '_products'];
+
+$viewsDir = __DIR__ . '/../app/Views';
+$updated  = 0;
+$skipped  = 0;
+$already  = 0;
+
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($viewsDir));
+
+foreach ($iterator as $file) {
+    if ($file->getExtension() !== 'php') continue;
+
+    $path     = $file->getPathname();
+    $folder   = basename(dirname($path));
+    $filename = $file->getBasename('.php');
+
+    // Skip partials, layouts, auth, pdf, ajax, standalone payment pages
+    if (in_array($folder, ['partials', 'layouts', 'auth', 'pdf', 'ajax', 'invoice-payment', 'booking-pay'])) {
+        $skipped++;
+        continue;
+    }
+
+    // Skip nav partials and print pages that have standalone <title>
+    if (in_array($filename, $skip)) {
+        $skipped++;
+        continue;
+    }
+
+    $content = file_get_contents($path);
+
+    // Skip if $pageTitle already set
+    if (strpos($content, '$pageTitle') !== false) {
+        $already++;
+        continue;
+    }
+
+    // Build title
+    $module = $moduleNames[$folder] ?? ucwords(str_replace('-', ' ', $folder));
+    $suffix = $fileTitles[$filename] ?? ucwords(str_replace('-', ' ', $filename));
+
+    $title = $suffix === '' ? $module : "$module — $suffix";
+
+    // Inject after opening <?php tag or at top
+    if (strpos($content, '<?php') === 0) {
+        $content = "<?php\n\$pageTitle = " . var_export($title, true) . ";\n" . substr($content, 5);
+    } elseif (strpos($content, "<?php\n") === 0) {
+        $content = "<?php\n\$pageTitle = " . var_export($title, true) . ";\n" . substr($content, 6);
+    } else {
+        // No opening PHP tag — prepend PHP block
+        $content = "<?php \$pageTitle = " . var_export($title, true) . "; ?>\n" . $content;
+    }
+
+    file_put_contents($path, $content);
+    echo "✅ $folder/$filename.php  →  \"$title\"\n";
+    $updated++;
+}
+
+echo "\n--- Done ---\n";
+echo "Updated : $updated\n";
+echo "Already : $already\n";
+echo "Skipped : $skipped\n";


### PR DESCRIPTION
## Summary
- Fix `<title>` tag in `head.php` — was hardcoded "CMS", now shows `Page — iACC`
- Add `$pageTitle` variable to 125 view files across all modules
- Add `scripts/add-page-titles.php` automation script for future views

## Modules covered
Tour Bookings, Invoices, Receipts, Journal, Expenses, PO/PR, Tax, Delivery, Voucher, Dashboard, API, AI, Dev Tools, LINE OA, Help, and more.

## Test plan
- [ ] Open any page — browser tab should show e.g. "Tour Bookings — iACC"
- [ ] List pages show module name only (e.g. "Tour Bookings — iACC")  
- [ ] Form pages show "New" suffix (e.g. "Tour Bookings — New — iACC")
- [ ] View/detail pages show "Details" suffix
- [ ] Pages without `$pageTitle` fall back to "iACC"

🤖 Generated with [Claude Code](https://claude.com/claude-code)