### PR TITLE
feat: tracker agent auto-update GitHub Projects on merge

### DIFF
--- a/.github/workflows/tracker-update.yml
+++ b/.github/workflows/tracker-update.yml
@@ -1,0 +1,141 @@
+# =============================================================================
+# Tracker Agent — Auto-update GitHub Projects on PR merge
+# =============================================================================
+#
+# Triggers when a PR is merged into develop.
+# Actions:
+#   1. Parse PR body for linked issues (#NNN or "Closes #NNN" / "Fixes #NNN")
+#   2. Move those issues to Done in Sprint Board (Project 11)
+#   3. Post a tracker summary comment on the PR
+#
+# Required secret: TRACKER_TOKEN
+#   A GitHub Personal Access Token (classic) with scopes:
+#     - repo (full)
+#     - project (read:project + write:project via project scope)
+#   Add at: Settings → Secrets and variables → Actions → New repository secret
+#
+# =============================================================================
+
+name: Tracker — Update Sprint Board on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+jobs:
+  update-board:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Extract linked issue numbers from PR body
+        id: parse
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Match: #123, closes #123, fixes #123, resolves #123 (case-insensitive)
+          ISSUES=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)?\s*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')
+          echo "Found issues: $ISSUES"
+          echo "issues=$ISSUES" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+
+      - name: Move linked issues to Done in Sprint Board
+        if: steps.parse.outputs.issues != ''
+        env:
+          GH_TOKEN: ${{ secrets.TRACKER_TOKEN }}
+          PROJECT_ID: "PVT_kwHOADbqcM4BMK9M"
+          STATUS_FIELD_ID: "PVTSSF_lAHOADbqcM4BMK9Mzg7h-VE"
+          DONE_OPTION_ID: "98236657"
+          REPO: ${{ github.repository }}
+          ISSUES: ${{ steps.parse.outputs.issues }}
+        run: |
+          for ISSUE_NUM in $ISSUES; do
+            echo "Processing issue #$ISSUE_NUM"
+
+            # Get issue node ID
+            NODE_ID=$(gh api graphql -f query="
+              {
+                repository(owner: \"$(echo $REPO | cut -d/ -f1)\", name: \"$(echo $REPO | cut -d/ -f2)\") {
+                  issue(number: $ISSUE_NUM) { id title }
+                }
+              }" --jq '.data.repository.issue.id // empty')
+
+            if [ -z "$NODE_ID" ]; then
+              echo "Issue #$ISSUE_NUM not found, skipping"
+              continue
+            fi
+
+            # Find item ID in project (add if not already there)
+            ITEM_ID=$(gh api graphql -f query="
+              mutation {
+                addProjectV2ItemById(input: {
+                  projectId: \"$PROJECT_ID\"
+                  contentId: \"$NODE_ID\"
+                }) { item { id } }
+              }" --jq '.data.addProjectV2ItemById.item.id')
+
+            if [ -z "$ITEM_ID" ]; then
+              echo "Could not add issue #$ISSUE_NUM to project, skipping"
+              continue
+            fi
+
+            # Set status to Done
+            gh api graphql -f query="
+              mutation {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: \"$PROJECT_ID\"
+                  itemId: \"$ITEM_ID\"
+                  fieldId: \"$STATUS_FIELD_ID\"
+                  value: { singleSelectOptionId: \"$DONE_OPTION_ID\" }
+                }) { projectV2Item { id } }
+              }" > /dev/null
+
+            echo "✅ Issue #$ISSUE_NUM → Done in Sprint Board"
+          done
+
+      - name: Post tracker summary comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.TRACKER_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          ISSUES: ${{ steps.parse.outputs.issues }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # Build issues list for comment
+          ISSUE_LIST=""
+          for ISSUE_NUM in $ISSUES; do
+            ISSUE_LIST="$ISSUE_LIST\n- [#$ISSUE_NUM](https://github.com/$REPO/issues/$ISSUE_NUM) → ✅ Done in Sprint Board"
+          done
+
+          if [ -z "$ISSUES" ]; then
+            ISSUE_LIST="\n- _(No linked issues found — add \`#NNN\` or \`Closes #NNN\` to PR body to auto-link)_"
+          fi
+
+          DATE=$(echo "$MERGED_AT" | cut -c1-10)
+
+          COMMENT="## 🤖 Tracker Agent — Merge Summary
+
+**PR:** #$PR_NUMBER $PR_TITLE
+**Merged by:** @$PR_AUTHOR → \`$BASE_BRANCH\`
+**Date:** $DATE
+
+### Issues updated
+$(echo -e "$ISSUE_LIST")
+
+### Sprint Board
+[View Sprint Board →](https://github.com/users/$(echo $REPO | cut -d/ -f1)/projects/11)
+
+---
+_Tracker Agent auto-updated GitHub Projects. To link issues, add \`Closes #NNN\` to your PR description._"
+
+          gh pr comment $PR_NUMBER --repo $REPO --body "$COMMENT"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that triggers on every PR merge to develop
- Parses PR body for linked issues (Closes #NNN / Fixes #NNN / #NNN)
- Moves linked issues to Done in Sprint Board (Project 11)
- Posts a tracker summary comment on the merged PR

## How to link issues going forward
Add to any PR body:
\`\`\`
Closes #50
Fixes #51
\`\`\`
The tracker will automatically mark them Done when merged.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)