### PR TITLE
fix: status badge contrast on dark header in booking view

### DIFF
--- a/app/Views/tour-booking/view.php
+++ b/app/Views/tour-booking/view.php
@@ -98,7 +98,7 @@ $messages = [
             <div class="header-text">
                 <h2><i class="fa fa-calendar-check-o"></i> <?= htmlspecialchars($booking['booking_number']) ?></h2>
                 <p>
-                    <span class="status-badge" style="background:<?= $sc['bg'] ?>; color:<?= $sc['color'] ?>;">
+                    <span class="status-badge status-<?= htmlspecialchars($booking['status']) ?>">
                         <i class="fa <?= $sc['icon'] ?>"></i> <?= $sc['label'] ?>
                     </span>
                 </p>

--- a/css/master-data.css
+++ b/css/master-data.css
@@ -157,6 +157,19 @@
     color: white !important;
 }
 
+/* Status badges inside header — solid colors + white text for contrast on dark gradient */
+.master-data-header .status-badge {
+    background: rgba(255,255,255,0.15) !important;
+    color: #fff !important;
+    border: 1px solid rgba(255,255,255,0.35);
+    backdrop-filter: blur(4px);
+}
+/* Per-status solid accent colours inside header */
+.master-data-header .status-badge.status-draft     { background: rgba(100,116,139,0.75) !important; }
+.master-data-header .status-badge.status-confirmed { background: rgba(5,150,105,0.85)   !important; }
+.master-data-header .status-badge.status-completed { background: rgba(37,99,235,0.85)   !important; }
+.master-data-header .status-badge.status-cancelled { background: rgba(220,38,38,0.85)   !important; }
+
 /* Module-specific header colors — override with inline style or data attribute */
 .master-data-header[data-theme="teal"] {
     background: linear-gradient(135deg, #0d9488, #0891b2);


### PR DESCRIPTION
## Summary
Status badge on the tour booking view header was gray/white and unreadable against the teal gradient background.

**Before:** pastel backgrounds (light gray/green/blue) — invisible on dark header
**After:** solid semi-transparent colours + white text per status

| Status | Badge colour |
|--------|-------------|
| Draft | Slate grey |
| Confirmed | Green |
| Completed | Blue |
| Cancelled | Red |