### PR TITLE
fix(db): pin DbConn session time_zone to +07:00 (Bangkok)

### DIFF
--- a/inc/class.dbconn.php
+++ b/inc/class.dbconn.php
@@ -47,7 +47,13 @@ class DbConn {
 		mysqli_query($this->conn, "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci");
 		mysqli_query($this->conn, "SET CHARACTER SET utf8mb4");
 		mysqli_query($this->conn, "SET COLLATION_CONNECTION = utf8mb4_unicode_ci");
-		
+
+		// Pin session timezone to Bangkok so MySQL NOW() agrees with PHP date().
+		// Without this, cPanel hosts whose server defaults to IST/UTC drift 1.5–7h
+		// from PHP's Asia/Bangkok, breaking task_queue.scheduled_for polling and
+		// any timestamp display logic that compares MySQL and PHP times.
+		mysqli_query($this->conn, "SET time_zone = '+07:00'");
+
 		// Register for compatibility layer
 		__registerMySQLCompatConnection($this);
 	}


### PR DESCRIPTION
## Summary

- Pin `DbConn` session timezone to `+07:00` (Asia/Bangkok) so MySQL `NOW()` agrees with PHP `date()` regardless of the underlying server's default timezone.
- Single-line addition in [inc/class.dbconn.php](inc/class.dbconn.php) — no schema change, no data migration.
- Forward-only fix — existing IST/UTC-stamped rows are NOT rewritten (documented in PM spec).

## Why now (P0)

v6.1 worker pipeline went live on staging today. Diagnosed during cron smoke-test:
- Staging cPanel host runs MySQL in **IST** (UTC+5:30) by default.
- PHP is set to `Asia/Bangkok` (UTC+7) via `inc/sys.configs.php`.
- 1.5h skew breaks `task_queue.scheduled_for <= NOW()` polling — PHP-enqueued tasks would sit `pending` for 1.5h before MySQL agreed they were due.
- All `created_at`, `updated_at`, `audit_logs.timestamp` rows silently 1.5h "in the past" relative to PHP-displayed time.

## Verification

Local Docker test (MySQL default = `SYSTEM`/UTC):

```
PHP timezone (date_default): Asia/Bangkok
MySQL session.time_zone   : +07:00
MySQL NOW()               : 2026-05-04 14:49:27
PHP   date()              : 2026-05-04 14:49:27
Skew (seconds)            : 0
RESULT: PASS
```

## Test plan

- [ ] Merge to `develop`, watch GitHub Actions deploy to `dev.iacc.f2.co.th`
- [ ] Probe via cron endpoint, confirm queue still drains in <60s with auto-cron
- [ ] Run on staging:
      ```sql
      SELECT @@session.time_zone, NOW(), UTC_TIMESTAMP();
      ```
      Expected: `+07:00`, Bangkok wall-clock, ~7h behind UTC.
- [ ] Enqueue marker `tz-fix-001`; expect cron pickup within one minute (was failing due to 1.5h IST skew before fix)
- [ ] No regression in worker `duration_ms` or `stale_reaped`

## Out of scope (explicit)

- Backfilling existing IST timestamps to Bangkok — risk/reward not justified for a hotfix.
- Switching the platform to UTC end-to-end — proper long-term refactor, separate issue.
- Audit of every `date()` call site for tz consistency — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
