### PR TITLE
fix(ci): read app version from committed version.json (was hardcoded "5.0-mvc")

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -103,11 +103,16 @@ jobs:
           fi
 
       - name: 🏷️ Generate version.json
+        # Read the canonical app version from the committed version.json,
+        # then re-render the file with deploy-time CI metadata. Without this,
+        # the version field was hardcoded "5.0-mvc" so every deploy silently
+        # regressed the release tag in the production footer.
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          APP_VERSION=$(jq -r '.version' version.json)
           cat > version.json <<EOF
           {
-            "version": "5.0-mvc",
+            "version": "${APP_VERSION}",
             "commit": "${{ github.sha }}",
             "commit_short": "${SHORT_SHA}",
             "branch": "${{ github.ref_name }}",


### PR DESCRIPTION
Found while closing v6.1: production footer was showing "5.0-mvc" despite `version.json` being correctly bumped to `6.1-task-queue-workers`. Root cause: `.github/workflows/deploy-production.yml` line 110 had a hardcoded literal string in its version.json template.

**Fix**: Read the canonical `version` field from the committed `version.json` via `jq`, then re-render with CI metadata (`commit`, `build_number`, `deployed_by`) layered on top.

**Verification plan after merge**:
```
curl -s https://iacc.f2.co.th/version.json | jq .version
# Expected: "6.1-task-queue-workers"
```

Pre-fix output (from this morning's deploy):
```json
{ "version": "5.0-mvc", "commit": "3cc46a4...", ... }
```

Staging workflow (`deploy-staging.yml`) doesn't generate version.json, so it already shows the right version (whatever's committed).