### PR TITLE
release(v6.2): Channel Health Monitor (#83) → production

### DIFF
--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -155,6 +155,11 @@ return [
     'admin_task_queue_delete'  => ['AdminTaskQueueController', 'delete'],
     'admin_task_queue_bulk'    => ['AdminTaskQueueController', 'bulk'],
 
+    // Channel Health Monitor (v6.2 #83)
+    'channel_health'             => ['ChannelHealthController', 'index'],
+    'channel_health_test_now'    => ['ChannelHealthController', 'testNow', 'standalone'],
+    'channel_health_acknowledge' => ['ChannelHealthController', 'acknowledge', 'standalone'],
+
     // ========== Phase 5A: Payment Gateway (MVC) ==========
     'payment_gateway_config' => ['PaymentGatewayController', 'index'],
     'payment_gateway_save'   => ['PaymentGatewayController', 'save'],

--- a/app/Controllers/ChannelHealthController.php
+++ b/app/Controllers/ChannelHealthController.php
@@ -1,0 +1,230 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\ChannelHealthLog;
+use App\Models\ChannelAlert;
+
+/**
+ * ChannelHealthController — admin dashboard for v6.2 #83.
+ *
+ * Routes (registered in app/Config/routes.php):
+ *   channel_health             GET  — main dashboard view
+ *   channel_health_test_now    POST — AJAX: enqueue an off-schedule heartbeat for one channel
+ *   channel_health_acknowledge POST — AJAX: mark an open alert as acknowledged
+ *
+ * Multi-tenant: every query filters by $this->user['com_id']. Super-admin
+ * cross-tenant view is a deferred enhancement (PM spec out-of-scope).
+ *
+ * Security:
+ *   - level >= 2 (admin) gate on every action
+ *   - CSRF token verified on every POST
+ *   - "Test now" rate-limited at the controller level (30s per channel per company)
+ */
+class ChannelHealthController extends BaseController
+{
+    private const ACCESS_DENIED_HTML =
+        '<div class="alert alert-danger m-4"><i class="fa fa-lock"></i> Access denied. Admin privileges required.</div>';
+
+    /** Rate limit window for the manual "Test now" button. */
+    private const TEST_NOW_RATE_LIMIT_SECONDS = 30;
+
+    /** GET — main dashboard view. */
+    public function index(): void
+    {
+        if ($this->user['level'] < 2) {
+            echo self::ACCESS_DENIED_HTML;
+            return;
+        }
+
+        $comId = intval($this->user['com_id']);
+        if ($comId <= 0) {
+            echo '<div class="alert alert-warning m-4">Pick a company first.</div>';
+            return;
+        }
+
+        $log    = new ChannelHealthLog($this->conn);
+        $alerts = new ChannelAlert($this->conn);
+
+        $latestPerChannel = $log->latestPerChannel($comId);
+        $statusCards      = $this->buildStatusCards($comId, $latestPerChannel, $log);
+        $openAlerts       = $alerts->listOpen($comId);
+        $timeline         = $log->recentTimeline($comId, 100);
+        $chartSeries      = $log->chartLast24h($comId);
+
+        $flash = [
+            'msg'  => $_GET['flash'] ?? '',
+            'type' => $_GET['flash_type'] ?? 'success',
+        ];
+
+        $this->render('admin/channel-health/index', [
+            'statusCards' => $statusCards,
+            'openAlerts'  => $openAlerts,
+            'timeline'    => $timeline,
+            'chartSeries' => $chartSeries,
+            'flash'       => $flash,
+            'channels'    => ChannelHealthLog::CHANNELS,
+        ]);
+    }
+
+    /** POST — enqueue off-schedule heartbeat for one channel. */
+    public function testNow(): void
+    {
+        header('Content-Type: application/json');
+
+        if ($this->user['level'] < 2) {
+            http_response_code(403);
+            echo json_encode(['ok' => false, 'error' => 'access_denied']);
+            return;
+        }
+        $this->verifyCsrf();
+
+        $comId   = intval($this->user['com_id']);
+        $channel = $_POST['channel'] ?? '';
+        if (!in_array($channel, ChannelHealthLog::CHANNELS, true)) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'error' => 'invalid_channel']);
+            return;
+        }
+
+        // Rate limit: don't let admins spam this. One test_now per channel per
+        // company per 30 seconds.
+        if ($this->isRateLimited($comId, $channel)) {
+            http_response_code(429);
+            echo json_encode([
+                'ok'    => false,
+                'error' => 'rate_limited',
+                'retry_after_seconds' => self::TEST_NOW_RATE_LIMIT_SECONDS,
+            ]);
+            return;
+        }
+
+        $payload = json_encode([
+            'channels'    => [$channel],
+            'triggered_by' => 'admin_test_now',
+            'admin_user_id' => intval($this->user['id']),
+        ]);
+        $payloadEsc = mysqli_real_escape_string($this->conn, $payload);
+
+        $sql = "INSERT INTO task_queue
+                  (company_id, task_type, payload, priority, status, scheduled_for, max_attempts)
+                VALUES
+                  ($comId, 'channel_heartbeat', '$payloadEsc', 1, 'pending', NOW(), 1)";
+
+        if (!mysqli_query($this->conn, $sql)) {
+            error_log('[ChannelHealthController::testNow] ' . mysqli_error($this->conn));
+            http_response_code(500);
+            echo json_encode(['ok' => false, 'error' => 'enqueue_failed']);
+            return;
+        }
+        echo json_encode(['ok' => true, 'task_id' => intval(mysqli_insert_id($this->conn))]);
+    }
+
+    /** POST — acknowledge one alert. */
+    public function acknowledge(): void
+    {
+        header('Content-Type: application/json');
+
+        if ($this->user['level'] < 2) {
+            http_response_code(403);
+            echo json_encode(['ok' => false, 'error' => 'access_denied']);
+            return;
+        }
+        $this->verifyCsrf();
+
+        $alertId = intval($_POST['alert_id'] ?? 0);
+        $comId   = intval($this->user['com_id']);
+        if ($alertId <= 0) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'error' => 'invalid_alert_id']);
+            return;
+        }
+
+        $alerts = new ChannelAlert($this->conn);
+        $alert  = $alerts->find($alertId, $comId);
+        if ($alert === null) {
+            http_response_code(404);
+            echo json_encode(['ok' => false, 'error' => 'not_found_or_wrong_tenant']);
+            return;
+        }
+
+        $ok = $alerts->acknowledge($alertId, intval($this->user['id']));
+        echo json_encode(['ok' => $ok]);
+    }
+
+    /**
+     * Build dashboard status cards by combining latest heartbeat + last 5 evaluation.
+     * Returns assoc array: channel_type → ['state'=>..., 'response_ms'=>..., 'ago'=>..., 'error'=>...].
+     *
+     * State machine matches Designer spec:
+     *   healthy        → last 5 all success
+     *   degraded       → 1-4 of last 5 failures
+     *   down           → all 5 of last 5 failures
+     *   not_configured → no credentials / latest row says not_configured
+     *   stale          → no row in last 30 minutes (worker may be down)
+     */
+    private function buildStatusCards(int $comId, array $latestPerChannel, ChannelHealthLog $log): array
+    {
+        $cards = [];
+        foreach (ChannelHealthLog::CHANNELS as $channel) {
+            $latest = $latestPerChannel[$channel] ?? null;
+            if ($latest === null) {
+                $cards[$channel] = ['state' => 'stale', 'response_ms' => null,
+                                    'ago_seconds' => null, 'error' => null,
+                                    'last_checked_at' => null];
+                continue;
+            }
+            $ago = time() - strtotime($latest['checked_at']);
+            if ($ago > 30 * 60) {
+                $cards[$channel] = ['state' => 'stale', 'response_ms' => null,
+                                    'ago_seconds' => $ago, 'error' => null,
+                                    'last_checked_at' => $latest['checked_at']];
+                continue;
+            }
+
+            if ($latest['status'] === ChannelHealthLog::STATUS_NOT_CONFIGURED) {
+                $cards[$channel] = ['state' => 'not_configured', 'response_ms' => null,
+                                    'ago_seconds' => $ago, 'error' => null,
+                                    'last_checked_at' => $latest['checked_at']];
+                continue;
+            }
+
+            $recent = $log->recentFor($comId, $channel, 5);
+            $failures = 0;
+            foreach ($recent as $r) if ($r['status'] === ChannelHealthLog::STATUS_FAILURE) $failures++;
+
+            $state = 'healthy';
+            if ($failures >= 5)      $state = 'down';
+            elseif ($failures >= 1)  $state = 'degraded';
+
+            $cards[$channel] = [
+                'state'           => $state,
+                'response_ms'     => isset($latest['response_ms']) ? intval($latest['response_ms']) : null,
+                'ago_seconds'     => $ago,
+                'error'           => $latest['error_message'] ?? null,
+                'last_checked_at' => $latest['checked_at'],
+            ];
+        }
+        return $cards;
+    }
+
+    /**
+     * Rate-limit check for "Test now" button. Returns true if currently rate-limited.
+     */
+    private function isRateLimited(int $comId, string $channel): bool
+    {
+        $channelEsc = mysqli_real_escape_string($this->conn, $channel);
+        $window = self::TEST_NOW_RATE_LIMIT_SECONDS;
+
+        $sql = "SELECT COUNT(*) AS c
+                  FROM task_queue
+                 WHERE company_id = $comId
+                   AND task_type = 'channel_heartbeat'
+                   AND JSON_EXTRACT(payload, '$.triggered_by') = 'admin_test_now'
+                   AND JSON_EXTRACT(payload, '$.channels[0]') = '\"$channelEsc\"'
+                   AND created_at >= NOW() - INTERVAL $window SECOND";
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) return false; // fail open — never block on a query error
+        $row = mysqli_fetch_assoc($res);
+        return intval($row['c'] ?? 0) > 0;
+    }
+}

--- a/app/Models/ChannelAlert.php
+++ b/app/Models/ChannelAlert.php
@@ -1,0 +1,156 @@
+<?php
+namespace App\Models;
+
+/**
+ * ChannelAlert — alert state machine for v6.2 #83.
+ *
+ * Owns the channel_alerts table. State transitions:
+ *   open ────► acknowledged ────► resolved (auto when channel comes back)
+ *        └────────────────────► resolved (auto when channel comes back)
+ *
+ * Email is sent only on transitions:
+ *   - on initial open  → "Alert: channel X is down"
+ *   - on resolved      → "Resolved: channel X is back online"
+ * Sustained downtime does NOT re-alert (alert_email_sent_count caps at 2).
+ */
+class ChannelAlert
+{
+    public const STATUS_OPEN         = 'open';
+    public const STATUS_ACKNOWLEDGED = 'acknowledged';
+    public const STATUS_RESOLVED     = 'resolved';
+
+    private \mysqli $conn;
+
+    public function __construct(\mysqli $conn)
+    {
+        $this->conn = $conn;
+    }
+
+    /**
+     * Find the currently-active alert (open OR acknowledged) for a channel,
+     * or null if no active alert exists.
+     */
+    public function activeFor(int $companyId, string $channelType): ?array
+    {
+        $channelType = mysqli_real_escape_string($this->conn, $channelType);
+        $sql = "SELECT *
+                  FROM channel_alerts
+                 WHERE company_id = $companyId
+                   AND channel_type = '$channelType'
+                   AND status IN ('open','acknowledged')
+                 ORDER BY opened_at DESC
+                 LIMIT 1";
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) {
+            error_log('[ChannelAlert::activeFor] ' . mysqli_error($this->conn));
+            return null;
+        }
+        $row = mysqli_fetch_assoc($res);
+        return $row ?: null;
+    }
+
+    /**
+     * Open a new alert. Caller must verify no active alert exists first
+     * (use activeFor() — DON'T duplicate).
+     */
+    public function open(int $companyId, string $channelType, ?string $channelRef, ?string $lastError): int
+    {
+        $channelType = mysqli_real_escape_string($this->conn, $channelType);
+        $channelRefSql = $channelRef !== null ? "'" . mysqli_real_escape_string($this->conn, $channelRef) . "'" : 'NULL';
+        $lastErrorSql  = $lastError !== null
+            ? "'" . mysqli_real_escape_string($this->conn, mb_substr($lastError, 0, 1024)) . "'"
+            : 'NULL';
+
+        $sql = "INSERT INTO channel_alerts
+                  (company_id, channel_type, channel_ref, status, opened_at, last_error)
+                VALUES
+                  ($companyId, '$channelType', $channelRefSql, 'open', NOW(), $lastErrorSql)";
+
+        if (!mysqli_query($this->conn, $sql)) {
+            error_log('[ChannelAlert::open] ' . mysqli_error($this->conn));
+            return 0;
+        }
+        return intval(mysqli_insert_id($this->conn));
+    }
+
+    /**
+     * Mark alert acknowledged (admin clicked the button).
+     * Suppresses repeat alerts within the same downtime episode.
+     */
+    public function acknowledge(int $alertId, int $userId): bool
+    {
+        $sql = "UPDATE channel_alerts
+                   SET status = 'acknowledged',
+                       acknowledged_at = NOW(),
+                       acknowledged_by = $userId
+                 WHERE id = $alertId
+                   AND status = 'open'";
+        if (!mysqli_query($this->conn, $sql)) {
+            error_log('[ChannelAlert::acknowledge] ' . mysqli_error($this->conn));
+            return false;
+        }
+        return mysqli_affected_rows($this->conn) > 0;
+    }
+
+    /**
+     * Resolve alert (channel came back up). Auto-fired by handler.
+     */
+    public function resolve(int $alertId): bool
+    {
+        $sql = "UPDATE channel_alerts
+                   SET status = 'resolved',
+                       resolved_at = NOW()
+                 WHERE id = $alertId
+                   AND status IN ('open','acknowledged')";
+        if (!mysqli_query($this->conn, $sql)) {
+            error_log('[ChannelAlert::resolve] ' . mysqli_error($this->conn));
+            return false;
+        }
+        return mysqli_affected_rows($this->conn) > 0;
+    }
+
+    /**
+     * Increment email-sent counter — used to cap notifications at 2 per episode
+     * (1 on open, 1 on resolved). Returns new count.
+     */
+    public function bumpEmailSentCount(int $alertId): int
+    {
+        $sql = "UPDATE channel_alerts
+                   SET alert_email_sent_count = alert_email_sent_count + 1
+                 WHERE id = $alertId";
+        mysqli_query($this->conn, $sql);
+
+        $sql2 = "SELECT alert_email_sent_count FROM channel_alerts WHERE id = $alertId";
+        $res = mysqli_query($this->conn, $sql2);
+        if (!$res) return 0;
+        $row = mysqli_fetch_assoc($res);
+        return intval($row['alert_email_sent_count'] ?? 0);
+    }
+
+    /**
+     * Open alerts for the dashboard panel (all channels for one company).
+     */
+    public function listOpen(int $companyId): array
+    {
+        $sql = "SELECT *
+                  FROM channel_alerts
+                 WHERE company_id = $companyId
+                   AND status IN ('open','acknowledged')
+                 ORDER BY opened_at DESC";
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) return [];
+        $rows = [];
+        while ($r = mysqli_fetch_assoc($res)) $rows[] = $r;
+        return $rows;
+    }
+
+    public function find(int $alertId, int $companyId): ?array
+    {
+        $sql = "SELECT * FROM channel_alerts
+                 WHERE id = $alertId AND company_id = $companyId LIMIT 1";
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) return null;
+        $row = mysqli_fetch_assoc($res);
+        return $row ?: null;
+    }
+}

--- a/app/Models/ChannelHealthLog.php
+++ b/app/Models/ChannelHealthLog.php
@@ -1,0 +1,199 @@
+<?php
+namespace App\Models;
+
+/**
+ * ChannelHealthLog — heartbeat log row writer + dashboard reader (v6.2 #83).
+ *
+ * Owns the channel_health_log table. Writes are append-only (no UPDATE / DELETE
+ * except the 30-day retention sweep). Reads serve the admin dashboard:
+ *   - last N rows for the timeline
+ *   - last 5 rows per (company, channel) for the consecutive-failure rule
+ *   - aggregated stats for the response-time chart
+ */
+class ChannelHealthLog
+{
+    private \mysqli $conn;
+
+    public const STATUS_SUCCESS         = 'success';
+    public const STATUS_FAILURE         = 'failure';
+    public const STATUS_NOT_CONFIGURED  = 'not_configured';
+
+    /** Channels supported in v6.2 MVP (#83). */
+    public const CHANNELS = ['line_oa', 'sales_channel_api', 'outbound_webhook', 'email_smtp'];
+
+    /** Consecutive failures that open an alert (matches PM spec AC3). */
+    public const FAILURE_THRESHOLD = 5;
+
+    public function __construct(\mysqli $conn)
+    {
+        $this->conn = $conn;
+    }
+
+    /**
+     * Append one heartbeat row.
+     *
+     * @param array $row [
+     *   'company_id'    => int,
+     *   'channel_type'  => string (one of CHANNELS),
+     *   'channel_ref'   => ?string,
+     *   'status'        => string (one of STATUS_*),
+     *   'response_ms'   => ?int,
+     *   'error_message' => ?string,
+     * ]
+     * @return int inserted id (0 on failure — caller checks mysqli_error)
+     */
+    public function insert(array $row): int
+    {
+        $companyId   = intval($row['company_id']);
+        $channelType = mysqli_real_escape_string($this->conn, $row['channel_type']);
+        $channelRef  = isset($row['channel_ref'])  ? "'" . mysqli_real_escape_string($this->conn, $row['channel_ref'])  . "'" : 'NULL';
+        $status      = mysqli_real_escape_string($this->conn, $row['status']);
+        $respMs      = $row['response_ms'] !== null ? intval($row['response_ms']) : 'NULL';
+        $errMsg      = isset($row['error_message']) && $row['error_message'] !== null
+            ? "'" . mysqli_real_escape_string($this->conn, mb_substr($row['error_message'], 0, 1024)) . "'"
+            : 'NULL';
+
+        $sql = "INSERT INTO channel_health_log
+                  (company_id, channel_type, channel_ref, status, response_ms, error_message)
+                VALUES
+                  ($companyId, '$channelType', $channelRef, '$status', $respMs, $errMsg)";
+
+        if (!mysqli_query($this->conn, $sql)) {
+            error_log('[ChannelHealthLog::insert] ' . mysqli_error($this->conn));
+            return 0;
+        }
+        return intval(mysqli_insert_id($this->conn));
+    }
+
+    /**
+     * Fetch the last N heartbeats for one (company, channel) — used to evaluate
+     * whether the channel is down (5 consecutive failures = open alert).
+     *
+     * Returns rows newest-first.
+     */
+    public function recentFor(int $companyId, string $channelType, int $limit = 5): array
+    {
+        $channelType = mysqli_real_escape_string($this->conn, $channelType);
+        $limit = max(1, min($limit, 100));
+
+        $sql = "SELECT id, status, response_ms, error_message, checked_at
+                  FROM channel_health_log
+                 WHERE company_id = $companyId
+                   AND channel_type = '$channelType'
+                 ORDER BY checked_at DESC, id DESC
+                 LIMIT $limit";
+
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) {
+            error_log('[ChannelHealthLog::recentFor] ' . mysqli_error($this->conn));
+            return [];
+        }
+        $rows = [];
+        while ($r = mysqli_fetch_assoc($res)) $rows[] = $r;
+        return $rows;
+    }
+
+    /**
+     * Are the last 5 heartbeats all failures? (PM spec AC3 trigger.)
+     */
+    public function hasConsecutiveFailures(int $companyId, string $channelType, int $threshold = self::FAILURE_THRESHOLD): bool
+    {
+        $rows = $this->recentFor($companyId, $channelType, $threshold);
+        if (count($rows) < $threshold) return false;
+        foreach ($rows as $r) {
+            if ($r['status'] !== self::STATUS_FAILURE) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Latest row per channel for the dashboard status grid.
+     * Returns assoc array keyed by channel_type → row (or null if no data).
+     */
+    public function latestPerChannel(int $companyId): array
+    {
+        $out = array_fill_keys(self::CHANNELS, null);
+
+        // Subquery picks max(checked_at) per channel; outer select grabs the row.
+        // Avoids window functions (MySQL 5.7 compat).
+        $sql = "SELECT chl.*
+                  FROM channel_health_log chl
+                  JOIN (
+                      SELECT channel_type, MAX(checked_at) AS max_at
+                        FROM channel_health_log
+                       WHERE company_id = $companyId
+                       GROUP BY channel_type
+                  ) latest
+                    ON chl.channel_type = latest.channel_type
+                   AND chl.checked_at   = latest.max_at
+                 WHERE chl.company_id = $companyId";
+
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) {
+            error_log('[ChannelHealthLog::latestPerChannel] ' . mysqli_error($this->conn));
+            return $out;
+        }
+        while ($r = mysqli_fetch_assoc($res)) {
+            $out[$r['channel_type']] = $r;
+        }
+        return $out;
+    }
+
+    /**
+     * Last N rows across all channels for the dashboard timeline.
+     */
+    public function recentTimeline(int $companyId, int $limit = 100): array
+    {
+        $limit = max(1, min($limit, 500));
+        $sql = "SELECT id, channel_type, channel_ref, status, response_ms, error_message, checked_at
+                  FROM channel_health_log
+                 WHERE company_id = $companyId
+                 ORDER BY checked_at DESC, id DESC
+                 LIMIT $limit";
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) return [];
+        $rows = [];
+        while ($r = mysqli_fetch_assoc($res)) $rows[] = $r;
+        return $rows;
+    }
+
+    /**
+     * 24h response time series for the chart, bucketed by hour and channel.
+     * Returns rows: { channel_type, hour_bucket, avg_ms, max_ms, fail_count }.
+     */
+    public function chartLast24h(int $companyId): array
+    {
+        $sql = "SELECT
+                    channel_type,
+                    DATE_FORMAT(checked_at, '%Y-%m-%d %H:00:00') AS hour_bucket,
+                    ROUND(AVG(response_ms))                      AS avg_ms,
+                    MAX(response_ms)                             AS max_ms,
+                    SUM(CASE WHEN status='failure' THEN 1 ELSE 0 END) AS fail_count
+                  FROM channel_health_log
+                 WHERE company_id = $companyId
+                   AND checked_at >= NOW() - INTERVAL 24 HOUR
+                 GROUP BY channel_type, hour_bucket
+                 ORDER BY hour_bucket ASC, channel_type ASC";
+        $res = mysqli_query($this->conn, $sql);
+        if (!$res) return [];
+        $rows = [];
+        while ($r = mysqli_fetch_assoc($res)) $rows[] = $r;
+        return $rows;
+    }
+
+    /**
+     * 30-day retention cleanup. Returns rows deleted.
+     * Called by a daily cron task (placeholder for v6.3 #92).
+     */
+    public function pruneOlderThan30Days(): int
+    {
+        $sql = "DELETE FROM channel_health_log
+                 WHERE checked_at < NOW() - INTERVAL 30 DAY
+                 LIMIT 10000"; // chunk to avoid long lock
+        if (!mysqli_query($this->conn, $sql)) {
+            error_log('[ChannelHealthLog::prune] ' . mysqli_error($this->conn));
+            return 0;
+        }
+        return mysqli_affected_rows($this->conn);
+    }
+}

--- a/app/Views/admin/channel-health/_alert_row.php
+++ b/app/Views/admin/channel-health/_alert_row.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Alert row partial — one open or acknowledged alert.
+ *
+ * Variables in scope (set by index.php foreach):
+ *   $a              — alert row from channel_alerts
+ *   $channelLabels  — assoc array channel_type → bilingual name
+ *   $isThai         — bool
+ */
+$alertChannel = $channelLabels[$a['channel_type']] ?? $a['channel_type'];
+$openedSeconds = time() - strtotime($a['opened_at']);
+$openedRel = ch_relative_time($openedSeconds, $isThai);
+$isAck = ($a['status'] === 'acknowledged');
+?>
+<div class="ch-alert-row" style="background:white;border:1px solid #fecaca;border-radius:6px;padding:10px 12px;margin-bottom:8px;<?= $isAck ? 'opacity:0.7;' : '' ?>">
+    <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;flex-wrap:wrap;">
+        <div style="flex:1;min-width:200px;">
+            <div style="font-weight:600;color:#991b1b;">
+                🔴 <?= htmlspecialchars($alertChannel) ?>
+                <?php if ($isAck): ?>
+                <span style="font-size:11px;font-weight:600;color:#92400e;background:#fef3c7;padding:1px 6px;border-radius:8px;margin-left:6px;">
+                    <?= $isThai ? 'รับทราบแล้ว' : 'Acknowledged' ?>
+                </span>
+                <?php endif; ?>
+            </div>
+            <div style="font-size:12px;color:#6b7280;margin-top:2px;">
+                <?= $isThai ? 'เปิดเมื่อ' : 'Opened' ?> <?= htmlspecialchars($openedRel) ?>
+                · <?= htmlspecialchars($a['opened_at']) ?>
+            </div>
+            <?php if (!empty($a['last_error'])): ?>
+            <div style="font-size:11px;color:#991b1b;margin-top:4px;font-style:italic;background:#fef2f2;padding:3px 6px;border-radius:4px;">
+                <?= htmlspecialchars(mb_substr((string)$a['last_error'], 0, 200)) ?>
+            </div>
+            <?php endif; ?>
+        </div>
+        <?php if (!$isAck): ?>
+        <div>
+            <button type="button" data-action="acknowledge" data-alert-id="<?= intval($a['id']) ?>"
+                    style="font-size:12px;padding:4px 10px;border-radius:4px;border:1px solid #fca5a5;background:white;color:#991b1b;cursor:pointer;">
+                <?= $isThai ? 'รับทราบ' : 'Acknowledge' ?>
+            </button>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/app/Views/admin/channel-health/_status_card.php
+++ b/app/Views/admin/channel-health/_status_card.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Status card partial — one channel.
+ *
+ * Variables in scope (set by index.php loop):
+ *   $channel    — channel_type key (e.g. 'line_oa')
+ *   $card       — ['state','response_ms','ago_seconds','error','last_checked_at']
+ *   $cardName   — bilingual display name (e.g. 'LINE OA' / 'ไลน์ OA')
+ *   $cardState  — state key ('healthy','degraded','down','not_configured','stale')
+ *   $cardLabel  — bilingual state label
+ *   $cardClass  — same as $cardState (used for CSS class)
+ *   $cardIcon   — emoji for the state
+ *   $isThai     — bool
+ */
+$canTest = in_array($cardState, ['healthy','degraded','down','stale'], true);
+?>
+<div class="ch-card">
+    <div class="ch-c-title"><?= $cardIcon ?> <?= htmlspecialchars($cardName) ?></div>
+    <span class="ch-c-state <?= htmlspecialchars($cardClass) ?>"><?= htmlspecialchars($cardLabel) ?></span>
+
+    <?php if ($card['response_ms'] !== null): ?>
+        <div class="ch-c-meta"><?= intval($card['response_ms']) ?> ms · <?= htmlspecialchars(ch_relative_time($card['ago_seconds'], $isThai)) ?></div>
+    <?php elseif ($card['ago_seconds'] !== null): ?>
+        <div class="ch-c-meta"><?= htmlspecialchars(ch_relative_time($card['ago_seconds'], $isThai)) ?></div>
+    <?php else: ?>
+        <div class="ch-c-meta">—</div>
+    <?php endif; ?>
+
+    <?php if (!empty($card['error'])): ?>
+    <div class="ch-c-error" title="<?= htmlspecialchars($card['error']) ?>">
+        <?= htmlspecialchars(mb_substr((string)$card['error'], 0, 80)) ?>
+    </div>
+    <?php endif; ?>
+
+    <div class="ch-c-actions">
+        <?php if ($canTest): ?>
+        <button type="button" data-action="test-now" data-channel="<?= htmlspecialchars($channel) ?>">
+            <?= $isThai ? 'ทดสอบ' : 'Test now' ?>
+        </button>
+        <?php else: ?>
+        <button type="button" disabled title="<?= $isThai ? 'ตั้งค่าช่องทางก่อนจึงจะทดสอบได้' : 'Configure channel before testing' ?>">
+            <?= $isThai ? 'ทดสอบ' : 'Test now' ?>
+        </button>
+        <?php endif; ?>
+    </div>
+</div>

--- a/app/Views/admin/channel-health/index.php
+++ b/app/Views/admin/channel-health/index.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Channel Health Dashboard (v6.2 #83)
+ *
+ * Variables passed from ChannelHealthController::index:
+ *   $statusCards   — assoc array channel_type → ['state','response_ms','ago_seconds','error','last_checked_at']
+ *   $openAlerts    — array of alert rows (status IN open, acknowledged)
+ *   $timeline      — array of last-100 heartbeat rows (newest first)
+ *   $chartSeries   — array of {channel_type, hour_bucket, avg_ms, max_ms, fail_count}
+ *   $flash         — ['msg' => ..., 'type' => 'success|warning|danger']
+ *   $channels      — list of channel_type keys (ChannelHealthLog::CHANNELS)
+ *   $user          — current user (com_id, level)
+ */
+$isThai = ($_SESSION['lang'] ?? '0') === '1';
+
+// Bilingual label tables — kept inline so this view is self-contained
+$channelLabels = [
+    'line_oa'           => $isThai ? 'ไลน์ OA'           : 'LINE OA',
+    'sales_channel_api' => $isThai ? 'API ขายช่องทาง'   : 'Sales Channel API',
+    'outbound_webhook'  => $isThai ? 'เว็บฮุคขาออก'      : 'Outbound Webhook',
+    'email_smtp'        => $isThai ? 'อีเมล SMTP'        : 'Email SMTP',
+];
+$stateLabels = [
+    'healthy'        => $isThai ? 'สถานะปกติ'         : 'Healthy',
+    'degraded'       => $isThai ? 'ผิดปกติบางส่วน'    : 'Degraded',
+    'down'           => $isThai ? 'ขัดข้อง'           : 'Down',
+    'not_configured' => $isThai ? 'ยังไม่ตั้งค่า'     : 'Not configured',
+    'stale'          => $isThai ? 'ไม่มีข้อมูลล่าสุด' : 'No recent data',
+];
+$stateClass = [
+    'healthy' => 'success', 'degraded' => 'warning',
+    'down' => 'danger', 'not_configured' => 'secondary', 'stale' => 'secondary',
+];
+$stateIcon = [
+    'healthy' => '🟢', 'degraded' => '🟡', 'down' => '🔴',
+    'not_configured' => '⚪', 'stale' => '⚪',
+];
+
+/** Format seconds-ago as "Xm ago" / "Xs ago" / "Xh ago" — bilingual. */
+function ch_relative_time($seconds, $isThai) {
+    if ($seconds === null) return $isThai ? 'ไม่มีข้อมูล' : 'no data';
+    $s = intval($seconds);
+    if ($s < 60)        return $isThai ? "$s วินาทีที่แล้ว"  : "{$s}s ago";
+    if ($s < 3600)      return $isThai ? floor($s/60) . " นาทีที่แล้ว" : floor($s/60) . "m ago";
+    if ($s < 86400)     return $isThai ? floor($s/3600) . " ชั่วโมงที่แล้ว" : floor($s/3600) . "h ago";
+    return $isThai ? floor($s/86400) . " วันที่แล้ว" : floor($s/86400) . "d ago";
+}
+?>
+<style>
+.ch-page {padding:24px;max-width:1600px;margin:0 auto;}
+.ch-header {display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px;}
+.ch-header h2 {margin:0;font-size:22px;color:#1f2937;}
+.ch-header .ch-meta {color:#6b7280;font-size:13px;}
+.ch-flash {padding:10px 14px;border-radius:6px;margin-bottom:14px;font-size:14px;}
+.ch-flash.success {background:#d1fae5;color:#065f46;}
+.ch-flash.warning {background:#fef3c7;color:#92400e;}
+.ch-flash.danger  {background:#fee2e2;color:#991b1b;}
+.ch-grid {display:grid;grid-template-columns:repeat(4, minmax(220px, 1fr));gap:14px;margin-bottom:20px;}
+@media (max-width:1024px) {.ch-grid {grid-template-columns:repeat(2, 1fr);}}
+@media (max-width:540px)  {.ch-grid {grid-template-columns:1fr;}}
+.ch-card {background:white;border:1px solid #e5e7eb;border-radius:10px;padding:14px;}
+.ch-card .ch-c-title {font-weight:600;color:#111827;font-size:14px;margin-bottom:6px;}
+.ch-card .ch-c-state {display:inline-block;padding:3px 10px;border-radius:14px;font-size:12px;font-weight:600;margin-bottom:6px;}
+.ch-card .ch-c-state.healthy        {background:#d1fae5;color:#065f46;}
+.ch-card .ch-c-state.degraded       {background:#fef3c7;color:#92400e;}
+.ch-card .ch-c-state.down           {background:#fee2e2;color:#991b1b;}
+.ch-card .ch-c-state.not_configured {background:#f3f4f6;color:#6b7280;}
+.ch-card .ch-c-state.stale          {background:#f3f4f6;color:#6b7280;background-image:repeating-linear-gradient(45deg,transparent,transparent 4px,#e5e7eb 4px,#e5e7eb 6px);}
+.ch-card .ch-c-meta {font-size:12px;color:#6b7280;margin-bottom:4px;}
+.ch-card .ch-c-error {font-size:11px;color:#991b1b;background:#fef2f2;padding:4px 6px;border-radius:4px;margin-top:6px;border-left:3px solid #ef4444;font-style:italic;word-break:break-word;}
+.ch-card .ch-c-actions {margin-top:8px;display:flex;gap:6px;}
+.ch-card .ch-c-actions button {font-size:11px;padding:3px 8px;border-radius:4px;border:1px solid #d1d5db;background:white;cursor:pointer;}
+.ch-card .ch-c-actions button:hover {background:#f9fafb;}
+.ch-card .ch-c-actions button:disabled {opacity:0.5;cursor:not-allowed;}
+.ch-alerts {background:#fef2f2;border:1px solid #fecaca;border-radius:10px;padding:14px;margin-bottom:20px;}
+.ch-alerts h3 {margin:0 0 10px;font-size:15px;color:#991b1b;font-weight:600;}
+.ch-alerts .ch-empty {color:#6b7280;font-size:13px;font-style:italic;}
+.ch-section {background:white;border:1px solid #e5e7eb;border-radius:10px;padding:14px;margin-bottom:20px;}
+.ch-section h3 {margin:0 0 12px;font-size:15px;color:#374151;font-weight:600;}
+.ch-section .ch-chart-box {position:relative;height:280px;}
+.ch-table {width:100%;border-collapse:collapse;font-size:13px;}
+.ch-table th, .ch-table td {padding:6px 10px;border-bottom:1px solid #f3f4f6;text-align:left;}
+.ch-table th {color:#6b7280;font-weight:600;font-size:12px;background:#f9fafb;text-transform:uppercase;letter-spacing:0.04em;}
+.ch-table tbody tr:hover {background:#f9fafb;}
+.ch-table .ch-t-status {display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;font-weight:600;}
+.ch-table .ch-t-status.success {background:#d1fae5;color:#065f46;}
+.ch-table .ch-t-status.failure {background:#fee2e2;color:#991b1b;}
+.ch-table .ch-t-status.not_configured {background:#f3f4f6;color:#6b7280;}
+.ch-table .ch-t-error {color:#991b1b;font-size:12px;font-style:italic;max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.ch-table-wrap {max-height:420px;overflow-y:auto;}
+@media (max-width:540px) {.ch-table {font-size:12px;} .ch-table th, .ch-table td {padding:4px 6px;}}
+</style>
+
+<div class="ch-page">
+    <div class="ch-header">
+        <div>
+            <h2><i class="fa fa-heartbeat"></i>
+                <?= $isThai ? 'สถานะช่องทางการขาย' : 'Channel Health Monitor' ?>
+            </h2>
+            <div class="ch-meta">
+                <?= $isThai
+                    ? 'ตรวจสอบทุก 5 นาที · แจ้งเตือนเมื่อล้มเหลวต่อเนื่อง 5 ครั้ง'
+                    : 'Heartbeat every 5 minutes · alert after 5 consecutive failures' ?>
+            </div>
+        </div>
+        <div>
+            <a href="index.php?page=channel_health" class="btn btn-sm btn-default">
+                <i class="fa fa-refresh"></i> <?= $isThai ? 'รีเฟรช' : 'Refresh' ?>
+            </a>
+        </div>
+    </div>
+
+    <?php if (!empty($flash['msg'])): ?>
+    <div class="ch-flash <?= htmlspecialchars($flash['type']) ?>">
+        <?= htmlspecialchars($flash['msg']) ?>
+    </div>
+    <?php endif; ?>
+
+    <!-- Status grid: 4 cards, 1 per channel -->
+    <div class="ch-grid">
+        <?php foreach ($channels as $channel):
+            $card = $statusCards[$channel] ?? ['state'=>'stale','response_ms'=>null,'ago_seconds'=>null,'error'=>null];
+            $cardName  = $channelLabels[$channel];
+            $cardState = $card['state'];
+            $cardLabel = $stateLabels[$cardState];
+            $cardClass = $cardState;
+            $cardIcon  = $stateIcon[$cardState];
+            include __DIR__ . '/_status_card.php';
+        endforeach; ?>
+    </div>
+
+    <!-- Open alerts panel -->
+    <div class="ch-alerts">
+        <h3><i class="fa fa-bell"></i>
+            <?= $isThai ? 'แจ้งเตือนที่เปิดอยู่' : 'Open alerts' ?>
+            <span style="background:#991b1b;color:white;padding:1px 8px;border-radius:10px;font-size:12px;font-weight:700;margin-left:6px;"><?= count($openAlerts) ?></span>
+        </h3>
+        <?php if (empty($openAlerts)): ?>
+            <div class="ch-empty">
+                <?= $isThai ? '✅ ไม่มีแจ้งเตือนในขณะนี้ — ทุกช่องทางทำงานปกติ' : '✅ No active alerts — all channels healthy' ?>
+            </div>
+        <?php else: ?>
+            <?php foreach ($openAlerts as $a) include __DIR__ . '/_alert_row.php'; ?>
+        <?php endif; ?>
+    </div>
+
+    <!-- 24h response time chart -->
+    <div class="ch-section">
+        <h3><?= $isThai ? 'เวลาตอบสนอง 24 ชั่วโมงล่าสุด (มิลลิวินาที)' : 'Response time — last 24h (ms)' ?></h3>
+        <div class="ch-chart-box">
+            <canvas id="chChart24h"></canvas>
+        </div>
+    </div>
+
+    <!-- Last 100 heartbeats timeline -->
+    <div class="ch-section">
+        <h3><?= $isThai ? 'ประวัติการตรวจสอบล่าสุด (100 รายการ)' : 'Recent heartbeats (last 100)' ?></h3>
+        <?php if (empty($timeline)): ?>
+            <div class="ch-empty"><?= $isThai
+                ? 'ระบบกำลังเริ่มต้น — ผลตรวจสอบจะแสดงภายใน 5 นาที'
+                : 'Health monitor starting up — first heartbeats arrive within 5 minutes.' ?></div>
+        <?php else: ?>
+        <div class="ch-table-wrap">
+        <table class="ch-table">
+            <thead>
+                <tr>
+                    <th><?= $isThai ? 'เวลา' : 'Time' ?></th>
+                    <th><?= $isThai ? 'ช่องทาง' : 'Channel' ?></th>
+                    <th><?= $isThai ? 'สถานะ' : 'Status' ?></th>
+                    <th><?= $isThai ? 'ตอบสนอง' : 'Response' ?></th>
+                    <th><?= $isThai ? 'ข้อผิดพลาด' : 'Error' ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($timeline as $row): ?>
+                <tr>
+                    <td><?= htmlspecialchars($row['checked_at']) ?></td>
+                    <td><?= htmlspecialchars($channelLabels[$row['channel_type']] ?? $row['channel_type']) ?></td>
+                    <td><span class="ch-t-status <?= htmlspecialchars($row['status']) ?>">
+                        <?= htmlspecialchars($row['status']) ?>
+                    </span></td>
+                    <td><?= $row['response_ms'] !== null ? intval($row['response_ms']).' ms' : '—' ?></td>
+                    <td class="ch-t-error" title="<?= htmlspecialchars((string)($row['error_message'] ?? '')) ?>">
+                        <?= htmlspecialchars(mb_substr((string)($row['error_message'] ?? ''), 0, 60)) ?>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<!-- Chart.js for the 24h chart -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<script>
+(function() {
+    'use strict';
+
+    // Build chart data from server-side $chartSeries.
+    // Format: array of {channel_type, hour_bucket, avg_ms, max_ms, fail_count}
+    var rawSeries = <?= json_encode($chartSeries, JSON_UNESCAPED_SLASHES) ?>;
+    var channelLabels = <?= json_encode($channelLabels, JSON_UNESCAPED_UNICODE) ?>;
+
+    // Pivot to chart format: one dataset per channel, x-axis = hour buckets
+    var hourSet = {};
+    var byChannel = {};
+    rawSeries.forEach(function(r) {
+        hourSet[r.hour_bucket] = true;
+        if (!byChannel[r.channel_type]) byChannel[r.channel_type] = {};
+        byChannel[r.channel_type][r.hour_bucket] = parseInt(r.avg_ms || 0);
+    });
+    var hourLabels = Object.keys(hourSet).sort();
+    var palette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'];
+    var datasets = [];
+    var ci = 0;
+    Object.keys(byChannel).forEach(function(channel) {
+        var data = hourLabels.map(function(h) {
+            return byChannel[channel][h] !== undefined ? byChannel[channel][h] : null;
+        });
+        datasets.push({
+            label: channelLabels[channel] || channel,
+            data: data,
+            borderColor: palette[ci % palette.length],
+            backgroundColor: palette[ci % palette.length] + '33',
+            tension: 0.25,
+            spanGaps: true,
+        });
+        ci++;
+    });
+
+    var canvas = document.getElementById('chChart24h');
+    if (canvas && hourLabels.length > 0 && typeof Chart !== 'undefined') {
+        new Chart(canvas, {
+            type: 'line',
+            data: { labels: hourLabels, datasets: datasets },
+            options: {
+                responsive: true, maintainAspectRatio: false,
+                plugins: { legend: { position: 'bottom' } },
+                scales: { y: { beginAtZero: true, title: { display: true, text: 'ms' } } }
+            }
+        });
+    } else if (canvas) {
+        canvas.parentElement.innerHTML =
+            '<div style="text-align:center;padding:40px;color:#9ca3af;font-style:italic;">' +
+            <?= $isThai ? "'ยังไม่มีข้อมูล 24 ชั่วโมง'" : "'No 24h data yet — chart will populate after a few heartbeats.'" ?> +
+            '</div>';
+    }
+
+    // ---- Test-now button handler ----
+    var csrfToken = '<?= htmlspecialchars(csrf_token()) ?>';
+    document.querySelectorAll('[data-action="test-now"]').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var channel = btn.getAttribute('data-channel');
+            btn.disabled = true;
+            btn.textContent = '<?= $isThai ? 'กำลังทดสอบ...' : 'Testing...' ?>';
+
+            var fd = new FormData();
+            fd.append('csrf_token', csrfToken);
+            fd.append('channel', channel);
+
+            fetch('index.php?page=channel_health_test_now', { method: 'POST', body: fd, credentials: 'same-origin' })
+                .then(function(r) { return r.json(); })
+                .then(function(j) {
+                    if (j.ok) {
+                        btn.textContent = '<?= $isThai ? '✓ เข้าคิวแล้ว' : '✓ Queued' ?>';
+                        setTimeout(function() { window.location.reload(); }, 2000);
+                    } else if (j.error === 'rate_limited') {
+                        btn.textContent = '<?= $isThai ? 'รอสักครู่' : 'Rate limited' ?>';
+                        setTimeout(function() { btn.disabled = false; btn.textContent = '<?= $isThai ? 'ทดสอบ' : 'Test now' ?>'; }, 5000);
+                    } else {
+                        btn.textContent = '<?= $isThai ? 'เกิดข้อผิดพลาด' : 'Error' ?>';
+                        setTimeout(function() { btn.disabled = false; btn.textContent = '<?= $isThai ? 'ทดสอบ' : 'Test now' ?>'; }, 3000);
+                    }
+                })
+                .catch(function() {
+                    btn.textContent = '<?= $isThai ? 'เครือข่ายล้มเหลว' : 'Network error' ?>';
+                    setTimeout(function() { btn.disabled = false; btn.textContent = '<?= $isThai ? 'ทดสอบ' : 'Test now' ?>'; }, 3000);
+                });
+        });
+    });
+
+    // ---- Acknowledge button handler ----
+    document.querySelectorAll('[data-action="acknowledge"]').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var alertId = btn.getAttribute('data-alert-id');
+            btn.disabled = true;
+
+            var fd = new FormData();
+            fd.append('csrf_token', csrfToken);
+            fd.append('alert_id', alertId);
+
+            fetch('index.php?page=channel_health_acknowledge', { method: 'POST', body: fd, credentials: 'same-origin' })
+                .then(function(r) { return r.json(); })
+                .then(function(j) {
+                    if (j.ok) {
+                        btn.closest('.ch-alert-row').style.opacity = '0.5';
+                        btn.textContent = '<?= $isThai ? '✓ รับทราบแล้ว' : '✓ Acknowledged' ?>';
+                    } else {
+                        btn.disabled = false;
+                        alert('<?= $isThai ? 'ไม่สามารถบันทึกได้' : 'Could not acknowledge' ?>');
+                    }
+                });
+        });
+    });
+})();
+</script>

--- a/app/Views/layouts/sidebar.php
+++ b/app/Views/layouts/sidebar.php
@@ -520,6 +520,9 @@ include_once 'inc/top-navbar.php';
                             <li>
                                 <a href="index.php?page=api_subscriptions"><i class="fa fa-users"></i> <?=$xml->apisubscriptions ?? 'Subscriptions'?></a>
                             </li>
+                            <li>
+                                <a href="index.php?page=channel_health"><i class="fa fa-heartbeat"></i> <?=$xml->channelhealth ?? 'Channel Health'?></a>
+                            </li>
                             <?php endif; ?>
                         </ul>
                     </li>

--- a/app/Workers/Handlers/ChannelHeartbeatHandler.php
+++ b/app/Workers/Handlers/ChannelHeartbeatHandler.php
@@ -1,0 +1,216 @@
+<?php
+namespace App\Workers\Handlers;
+
+use App\Models\ChannelHealthLog;
+use App\Models\ChannelAlert;
+
+/**
+ * ChannelHeartbeatHandler — v6.2 #83.
+ *
+ * Task type: 'channel_heartbeat'
+ * Runs once every 5 minutes (re-enqueues itself on success). Probes each
+ * registered channel for the tenant, writes a row to channel_health_log per
+ * channel, and evaluates alert state transitions.
+ *
+ * Payload:
+ *   {} — no payload required. The handler iterates all CHANNELS by default.
+ *   { "channels": ["line_oa"] } — restrict to specific channels (used by "Test now" button).
+ *
+ * Result (written to task_results.result_data):
+ *   {
+ *     "company_id": 123,
+ *     "channels_probed": 4,
+ *     "results": [{ "channel": "line_oa", "status": "success", "response_ms": 245 }, ...],
+ *     "alerts_opened": 1, "alerts_resolved": 0,
+ *     "next_scheduled_for": "2026-05-05 01:30:00"
+ *   }
+ *
+ * Invariants:
+ *  - Always writes one channel_health_log row per channel probed (even on
+ *    not_configured) so the dashboard "stale" detection works.
+ *  - Alert email sending is delegated to a helper hook that returns void
+ *    (logs but never throws — email failure must not abort the heartbeat).
+ *
+ * NOT yet implemented (scoped to v6.2.x iteration):
+ *  - Real probes for line_oa / sales_channel_api / outbound_webhook /
+ *    email_smtp. Current implementation returns 'not_configured' for all
+ *    channels except a stubbed 'sales_channel_api' that always succeeds —
+ *    enough to wire the pipeline end-to-end. Real prober classes ship next.
+ */
+class ChannelHeartbeatHandler implements TaskHandler
+{
+    /** Tighter cap than default — channel APIs misbehave; don't tie up the queue. */
+    public static int $maxAttempts = 3;
+
+    /** Re-enqueue interval (matches PM spec AC1). */
+    public const INTERVAL_MINUTES = 5;
+
+    public function handle(array $payload, array $context): array
+    {
+        global $db;
+        $conn = $db->conn;
+
+        $companyId = intval($context['company_id']);
+        if ($companyId <= 0) {
+            // Heartbeat must be tenant-scoped. Caller is responsible for
+            // enqueuing per-tenant tasks (the scheduler — v6.2.x follow-up).
+            throw new \RuntimeException('ChannelHeartbeatHandler requires company_id in context');
+        }
+
+        $log    = new ChannelHealthLog($conn);
+        $alerts = new ChannelAlert($conn);
+
+        $channels = isset($payload['channels']) && is_array($payload['channels'])
+            ? array_intersect($payload['channels'], ChannelHealthLog::CHANNELS)
+            : ChannelHealthLog::CHANNELS;
+
+        $results        = [];
+        $alertsOpened   = 0;
+        $alertsResolved = 0;
+
+        foreach ($channels as $channel) {
+            $probe = $this->probe($channel, $companyId);
+
+            $log->insert([
+                'company_id'    => $companyId,
+                'channel_type'  => $channel,
+                'channel_ref'   => $probe['channel_ref'] ?? null,
+                'status'        => $probe['status'],
+                'response_ms'   => $probe['response_ms'] ?? null,
+                'error_message' => $probe['error'] ?? null,
+            ]);
+
+            // Alert state transitions
+            $active = $alerts->activeFor($companyId, $channel);
+            if ($probe['status'] === ChannelHealthLog::STATUS_FAILURE
+                && $active === null
+                && $log->hasConsecutiveFailures($companyId, $channel)) {
+
+                $alertId = $alerts->open($companyId, $channel, $probe['channel_ref'] ?? null, $probe['error'] ?? null);
+                $this->sendAlertEmail($conn, $companyId, $channel, 'opened', $probe['error'] ?? null);
+                $alerts->bumpEmailSentCount($alertId);
+                $alertsOpened++;
+
+            } elseif ($probe['status'] === ChannelHealthLog::STATUS_SUCCESS && $active !== null) {
+
+                $alerts->resolve(intval($active['id']));
+                $this->sendAlertEmail($conn, $companyId, $channel, 'resolved', null);
+                $alerts->bumpEmailSentCount(intval($active['id']));
+                $alertsResolved++;
+            }
+
+            $results[] = [
+                'channel'      => $channel,
+                'status'       => $probe['status'],
+                'response_ms'  => $probe['response_ms'] ?? null,
+                'error'        => $probe['error']       ?? null,
+            ];
+        }
+
+        // Self-reschedule for the next tick (AC1). Worker writes attempts++,
+        // so this enqueue must NOT be tied to the current task row's lifecycle —
+        // we simply append a fresh row.
+        $nextRunAt = $this->scheduleNext($conn, $companyId);
+
+        return [
+            'company_id'         => $companyId,
+            'channels_probed'    => count($channels),
+            'results'            => $results,
+            'alerts_opened'      => $alertsOpened,
+            'alerts_resolved'    => $alertsResolved,
+            'next_scheduled_for' => $nextRunAt,
+        ];
+    }
+
+    /**
+     * Probe one channel — returns an outcome shape:
+     *   ['status' => 'success'|'failure'|'not_configured',
+     *    'response_ms' => ?int, 'error' => ?string, 'channel_ref' => ?string]
+     *
+     * MVP stub: only 'sales_channel_api' returns success; others return
+     * 'not_configured'. Replace with real prober classes (Phase 4.5 follow-up).
+     */
+    private function probe(string $channel, int $companyId): array
+    {
+        $started = microtime(true);
+
+        switch ($channel) {
+            case 'sales_channel_api':
+                // Cheap self-check: probe our own /api/health endpoint via loopback.
+                // If we can't reach our own API, that's a real platform problem.
+                $url = $this->resolveSelfApiHealth();
+                $ctx = stream_context_create(['http' => ['timeout' => 3, 'ignore_errors' => true]]);
+                $body = @file_get_contents($url, false, $ctx);
+                $ms = intval((microtime(true) - $started) * 1000);
+                if ($body === false) {
+                    return ['status' => ChannelHealthLog::STATUS_FAILURE, 'response_ms' => $ms,
+                            'error' => 'self-api unreachable', 'channel_ref' => $url];
+                }
+                return ['status' => ChannelHealthLog::STATUS_SUCCESS, 'response_ms' => $ms,
+                        'channel_ref' => $url];
+
+            case 'line_oa':
+            case 'outbound_webhook':
+            case 'email_smtp':
+            default:
+                // Real probers ship next iteration. Until then, mark as not_configured
+                // so the dashboard renders gracefully without false-alarming.
+                return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
+        }
+    }
+
+    /**
+     * Resolve the URL to ping for sales_channel_api self-check.
+     * Falls back to localhost if no host header in current request context.
+     */
+    private function resolveSelfApiHealth(): string
+    {
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        return "$scheme://$host/?page=health";
+    }
+
+    /**
+     * Re-enqueue a heartbeat task for this tenant in INTERVAL_MINUTES.
+     * Returns the scheduled_for timestamp string for inclusion in the result.
+     */
+    private function scheduleNext(\mysqli $conn, int $companyId): string
+    {
+        $payload = json_encode(['scheduled_by' => 'ChannelHeartbeatHandler']);
+        $payloadEsc = mysqli_real_escape_string($conn, $payload);
+
+        $sql = "INSERT INTO task_queue
+                  (company_id, task_type, payload, priority, status, scheduled_for, max_attempts)
+                VALUES
+                  ($companyId, 'channel_heartbeat', '$payloadEsc', 5, 'pending',
+                   DATE_ADD(NOW(), INTERVAL " . self::INTERVAL_MINUTES . " MINUTE), 3)";
+
+        if (!mysqli_query($conn, $sql)) {
+            error_log('[ChannelHeartbeatHandler::scheduleNext] ' . mysqli_error($conn));
+            return '';
+        }
+
+        $r = mysqli_query($conn, "SELECT DATE_ADD(NOW(), INTERVAL " . self::INTERVAL_MINUTES . " MINUTE) AS t");
+        $row = mysqli_fetch_assoc($r);
+        return $row['t'] ?? '';
+    }
+
+    /**
+     * Email alerter — fire-and-forget. Never throws.
+     * Real implementation will use App\Services\EmailService; for now, log.
+     */
+    private function sendAlertEmail(\mysqli $conn, int $companyId, string $channel, string $event, ?string $error): void
+    {
+        try {
+            // TODO Phase 4.5: integrate with App\Services\EmailService for the
+            // production email send. For MVP, log the intent — admins still see
+            // the alert in the dashboard; email is a nice-to-have for alerting.
+            error_log(sprintf(
+                '[ChannelHeartbeatHandler::sendAlertEmail] company=%d channel=%s event=%s error=%s',
+                $companyId, $channel, $event, $error ?? '-'
+            ));
+        } catch (\Throwable $e) {
+            error_log('[ChannelHeartbeatHandler::sendAlertEmail FAIL] ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Workers/Handlers/ChannelHeartbeatHandler.php
+++ b/app/Workers/Handlers/ChannelHeartbeatHandler.php
@@ -126,37 +126,166 @@ class ChannelHeartbeatHandler implements TaskHandler
      * Probe one channel — returns an outcome shape:
      *   ['status' => 'success'|'failure'|'not_configured',
      *    'response_ms' => ?int, 'error' => ?string, 'channel_ref' => ?string]
-     *
-     * MVP stub: only 'sales_channel_api' returns success; others return
-     * 'not_configured'. Replace with real prober classes (Phase 4.5 follow-up).
      */
     private function probe(string $channel, int $companyId): array
     {
+        switch ($channel) {
+            case 'sales_channel_api':  return $this->probeSalesChannelApi();
+            case 'line_oa':            return $this->probeLineOa($companyId);
+            case 'outbound_webhook':   return $this->probeOutboundWebhook($companyId);
+            case 'email_smtp':         return $this->probeEmailSmtp($companyId);
+            default:                   return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
+        }
+    }
+
+    /** Self-loopback probe to /?page=health. */
+    private function probeSalesChannelApi(): array
+    {
+        $started = microtime(true);
+        $url = $this->resolveSelfApiHealth();
+        $ctx = stream_context_create(['http' => ['timeout' => 3, 'ignore_errors' => true]]);
+        $body = @file_get_contents($url, false, $ctx);
+        $ms = intval((microtime(true) - $started) * 1000);
+        if ($body === false) {
+            return ['status' => ChannelHealthLog::STATUS_FAILURE, 'response_ms' => $ms,
+                    'error' => 'self-api unreachable', 'channel_ref' => $url];
+        }
+        return ['status' => ChannelHealthLog::STATUS_SUCCESS, 'response_ms' => $ms,
+                'channel_ref' => $url];
+    }
+
+    /**
+     * LINE OA — call /v2/bot/info with the company's channel access token.
+     * Lightweight read-only API; no message sent, no rate limit risk.
+     */
+    private function probeLineOa(int $companyId): array
+    {
+        global $db;
+        $sql = "SELECT channel_access_token, channel_id
+                  FROM line_oa_config
+                 WHERE company_id = $companyId AND is_active = 1 AND deleted_at IS NULL
+                 LIMIT 1";
+        $res = mysqli_query($db->conn, $sql);
+        $cfg = $res ? mysqli_fetch_assoc($res) : null;
+        if (!$cfg || empty($cfg['channel_access_token'])) {
+            return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
+        }
+
+        $started = microtime(true);
+        $ctx = stream_context_create([
+            'http' => [
+                'method'  => 'GET',
+                'header'  => "Authorization: Bearer " . trim($cfg['channel_access_token']) . "\r\n",
+                'timeout' => 5,
+                'ignore_errors' => true,
+            ],
+        ]);
+        $body = @file_get_contents('https://api.line.me/v2/bot/info', false, $ctx);
+        $ms = intval((microtime(true) - $started) * 1000);
+        $code = $this->httpStatusFromHeaders($http_response_header ?? []);
+
+        if ($body !== false && $code >= 200 && $code < 300) {
+            return ['status' => ChannelHealthLog::STATUS_SUCCESS, 'response_ms' => $ms,
+                    'channel_ref' => $cfg['channel_id'] ?: 'line_oa'];
+        }
+        $err = $code > 0 ? "HTTP $code from LINE API" : 'LINE API unreachable';
+        return ['status' => ChannelHealthLog::STATUS_FAILURE, 'response_ms' => $ms,
+                'error' => $err, 'channel_ref' => $cfg['channel_id'] ?: 'line_oa'];
+    }
+
+    /**
+     * Outbound webhook — passive prober. Reads delivery telemetry over the
+     * last 30 minutes from api_webhook_deliveries and computes success rate.
+     * Avoids firing test pings (which could be noisy / unsafe to subscribers).
+     *
+     * Logic:
+     *   - No webhooks registered → not_configured
+     *   - Active webhooks but zero deliveries in 30 min → not_configured (no signal)
+     *   - Deliveries exist:
+     *       success_rate >= 50% → success
+     *       success_rate <  50% → failure
+     */
+    private function probeOutboundWebhook(int $companyId): array
+    {
+        global $db;
         $started = microtime(true);
 
-        switch ($channel) {
-            case 'sales_channel_api':
-                // Cheap self-check: probe our own /api/health endpoint via loopback.
-                // If we can't reach our own API, that's a real platform problem.
-                $url = $this->resolveSelfApiHealth();
-                $ctx = stream_context_create(['http' => ['timeout' => 3, 'ignore_errors' => true]]);
-                $body = @file_get_contents($url, false, $ctx);
-                $ms = intval((microtime(true) - $started) * 1000);
-                if ($body === false) {
-                    return ['status' => ChannelHealthLog::STATUS_FAILURE, 'response_ms' => $ms,
-                            'error' => 'self-api unreachable', 'channel_ref' => $url];
-                }
-                return ['status' => ChannelHealthLog::STATUS_SUCCESS, 'response_ms' => $ms,
-                        'channel_ref' => $url];
-
-            case 'line_oa':
-            case 'outbound_webhook':
-            case 'email_smtp':
-            default:
-                // Real probers ship next iteration. Until then, mark as not_configured
-                // so the dashboard renders gracefully without false-alarming.
-                return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
+        $countSql = "SELECT COUNT(*) AS c FROM api_webhooks
+                      WHERE company_id = $companyId AND is_active = 1";
+        $r = mysqli_query($db->conn, $countSql);
+        $cfgRow = $r ? mysqli_fetch_assoc($r) : null;
+        if (!$cfgRow || intval($cfgRow['c']) === 0) {
+            return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
         }
+
+        $statsSql = "SELECT
+                        SUM(success)                            AS ok_count,
+                        COUNT(*)                                AS total,
+                        SUBSTRING_INDEX(GROUP_CONCAT(error ORDER BY created_at DESC), ',', 1) AS last_error
+                      FROM api_webhook_deliveries d
+                      JOIN api_webhooks w ON w.id = d.webhook_id
+                     WHERE w.company_id = $companyId
+                       AND d.created_at >= NOW() - INTERVAL 30 MINUTE";
+        $r = mysqli_query($db->conn, $statsSql);
+        $row = $r ? mysqli_fetch_assoc($r) : null;
+        $ms = intval((microtime(true) - $started) * 1000);
+
+        if (!$row || intval($row['total']) === 0) {
+            return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED, 'response_ms' => $ms];
+        }
+        $okCount = intval($row['ok_count']);
+        $total   = intval($row['total']);
+        $rate    = $total > 0 ? ($okCount / $total) : 0;
+        if ($rate >= 0.5) {
+            return ['status' => ChannelHealthLog::STATUS_SUCCESS, 'response_ms' => $ms,
+                    'channel_ref' => "$okCount/$total ok last 30min"];
+        }
+        return ['status' => ChannelHealthLog::STATUS_FAILURE, 'response_ms' => $ms,
+                'error' => "Only $okCount/$total succeeded; latest: " . substr((string)$row['last_error'], 0, 200),
+                'channel_ref' => "$okCount/$total"];
+    }
+
+    /**
+     * Email SMTP — open a TCP connection to the configured SMTP host:port.
+     * Cheapest possible probe: doesn't EHLO, doesn't authenticate, doesn't send.
+     * If the host is reachable on the port within 3s, count as healthy.
+     */
+    private function probeEmailSmtp(int $companyId): array
+    {
+        global $db;
+        try {
+            $svc = new \App\Services\EmailService($db->conn, $companyId);
+            $cfg = $svc->loadConfig();
+        } catch (\Throwable $e) {
+            return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
+        }
+        $host = trim($cfg['smtp_host'] ?? '');
+        $port = intval($cfg['smtp_port'] ?? 0);
+        if ($host === '' || $port <= 0) {
+            return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
+        }
+
+        $started = microtime(true);
+        $errno = 0; $errstr = '';
+        $sock = @fsockopen($host, $port, $errno, $errstr, 3);
+        $ms = intval((microtime(true) - $started) * 1000);
+        if ($sock) {
+            fclose($sock);
+            return ['status' => ChannelHealthLog::STATUS_SUCCESS, 'response_ms' => $ms,
+                    'channel_ref' => "$host:$port"];
+        }
+        return ['status' => ChannelHealthLog::STATUS_FAILURE, 'response_ms' => $ms,
+                'error' => "TCP connect failed: $errstr (errno=$errno)",
+                'channel_ref' => "$host:$port"];
+    }
+
+    /** Parse the numeric HTTP status code from $http_response_header. */
+    private function httpStatusFromHeaders(array $headers): int
+    {
+        foreach ($headers as $h) {
+            if (preg_match('~^HTTP/\S+\s+(\d+)~', $h, $m)) return intval($m[1]);
+        }
+        return 0;
     }
 
     /**
@@ -197,20 +326,116 @@ class ChannelHeartbeatHandler implements TaskHandler
 
     /**
      * Email alerter — fire-and-forget. Never throws.
-     * Real implementation will use App\Services\EmailService; for now, log.
+     * Sends bilingual (TH/EN stacked) email to all admins (level >= 2) of the company.
      */
     private function sendAlertEmail(\mysqli $conn, int $companyId, string $channel, string $event, ?string $error): void
     {
         try {
-            // TODO Phase 4.5: integrate with App\Services\EmailService for the
-            // production email send. For MVP, log the intent — admins still see
-            // the alert in the dashboard; email is a nice-to-have for alerting.
+            $admins = $this->lookupAdminEmails($conn, $companyId);
+            if (empty($admins)) {
+                error_log("[ChannelHeartbeatHandler::sendAlertEmail] no admin emails for company=$companyId");
+                return;
+            }
+            $channelName = $this->channelDisplayName($channel);
+            $subject = $event === 'opened'
+                ? "[iACC] Alert: $channelName channel is down"
+                : "[iACC] Resolved: $channelName channel is back online";
+            $html = $this->renderAlertHtml($event, $channelName, $error);
+            $text = $this->renderAlertText($event, $channelName, $error);
+
+            $svc = new \App\Services\EmailService($conn, $companyId);
+            // EmailService::send accepts a single recipient string or array
+            $svc->send($admins, $subject, $html, $text);
+
             error_log(sprintf(
-                '[ChannelHeartbeatHandler::sendAlertEmail] company=%d channel=%s event=%s error=%s',
-                $companyId, $channel, $event, $error ?? '-'
+                '[ChannelHeartbeatHandler::sendAlertEmail] sent company=%d channel=%s event=%s recipients=%d',
+                $companyId, $channel, $event, count($admins)
             ));
         } catch (\Throwable $e) {
+            // Email failures must NOT abort the heartbeat — alert state is in DB,
+            // dashboard surfaces it regardless of email delivery.
             error_log('[ChannelHeartbeatHandler::sendAlertEmail FAIL] ' . $e->getMessage());
         }
+    }
+
+    /** Resolve admin emails for a company. Returns array of email strings. */
+    private function lookupAdminEmails(\mysqli $conn, int $companyId): array
+    {
+        $sql = "SELECT DISTINCT email
+                  FROM authorize
+                 WHERE company_id = $companyId
+                   AND email IS NOT NULL
+                   AND email != ''
+                   AND (locked_until IS NULL OR locked_until < NOW())
+                   AND (level >= 2 OR is_admin = 1)
+                 LIMIT 10";
+        $res = @mysqli_query($conn, $sql);
+        if (!$res) {
+            // authorize table may have a different "admin" indicator; fall back simpler
+            $sql = "SELECT DISTINCT email FROM authorize
+                     WHERE company_id = $companyId AND email IS NOT NULL AND email != '' LIMIT 10";
+            $res = mysqli_query($conn, $sql);
+        }
+        $out = [];
+        if ($res) {
+            while ($r = mysqli_fetch_assoc($res)) $out[] = $r['email'];
+        }
+        return $out;
+    }
+
+    /** Bilingual display name for a channel (used in email subject + body). */
+    private function channelDisplayName(string $channel): string
+    {
+        $map = [
+            'line_oa'           => 'LINE OA',
+            'sales_channel_api' => 'Sales Channel API',
+            'outbound_webhook'  => 'Outbound Webhook',
+            'email_smtp'        => 'Email SMTP',
+        ];
+        return $map[$channel] ?? $channel;
+    }
+
+    private function renderAlertHtml(string $event, string $channelName, ?string $error): string
+    {
+        $errPreview = htmlspecialchars((string)($error ?? '—'));
+        if ($event === 'opened') {
+            $titleEn = "Alert: $channelName channel is down";
+            $titleTh = "แจ้งเตือน: ช่องทาง $channelName ขัดข้อง";
+            $bodyEn  = "The $channelName channel has failed 5 consecutive heartbeats and is now flagged as down.";
+            $bodyTh  = "ช่องทาง $channelName ตรวจพบความล้มเหลวต่อเนื่อง 5 ครั้ง จึงถูกตั้งสถานะเป็นขัดข้อง";
+        } else {
+            $titleEn = "Resolved: $channelName channel is back online";
+            $titleTh = "กลับมาใช้งานได้: ช่องทาง $channelName";
+            $bodyEn  = "The $channelName channel has recovered and is responding normally.";
+            $bodyTh  = "ช่องทาง $channelName กลับมาตอบสนองตามปกติแล้ว";
+        }
+        return "<!doctype html><html><body style=\"font-family:Arial,sans-serif;color:#1f2937;\">"
+             . "<h2 style=\"color:" . ($event === 'opened' ? '#991b1b' : '#065f46') . ";\">$titleEn</h2>"
+             . "<p>$bodyEn</p>"
+             . "<p style=\"font-family:monospace;background:#f9fafb;padding:8px;border-left:3px solid #ef4444;\">$errPreview</p>"
+             . "<hr style=\"border:0;border-top:1px solid #e5e7eb;margin:20px 0;\">"
+             . "<h3 style=\"color:" . ($event === 'opened' ? '#991b1b' : '#065f46') . ";\">$titleTh</h3>"
+             . "<p>$bodyTh</p>"
+             . "<p style=\"color:#6b7280;font-size:12px;margin-top:24px;\">— iACC Channel Health Monitor</p>"
+             . "</body></html>";
+    }
+
+    private function renderAlertText(string $event, string $channelName, ?string $error): string
+    {
+        $err = (string)($error ?? '—');
+        if ($event === 'opened') {
+            return "[Alert] $channelName channel is down\n\n"
+                 . "5 consecutive heartbeats failed.\n"
+                 . "Latest error: $err\n\n"
+                 . "[แจ้งเตือน] ช่องทาง $channelName ขัดข้อง\n"
+                 . "ตรวจพบความล้มเหลวต่อเนื่อง 5 ครั้ง\n"
+                 . "ข้อผิดพลาดล่าสุด: $err\n\n"
+                 . "— iACC Channel Health Monitor";
+        }
+        return "[Resolved] $channelName channel is back online\n\n"
+             . "Channel is responding normally again.\n\n"
+             . "[กลับมาใช้งานได้] ช่องทาง $channelName\n"
+             . "ช่องทางกลับมาตอบสนองตามปกติแล้ว\n\n"
+             . "— iACC Channel Health Monitor";
     }
 }

--- a/app/Workers/WorkerRunner.php
+++ b/app/Workers/WorkerRunner.php
@@ -34,7 +34,8 @@ class WorkerRunner
      * Adding a new task type: one line below + create the handler class.
      */
     private const HANDLERS = [
-        'echo' => Handlers\EchoHandler::class,
+        'echo'              => Handlers\EchoHandler::class,
+        'channel_heartbeat' => Handlers\ChannelHeartbeatHandler::class,
         // future: 'send_email' => Handlers\SendEmailHandler::class,
         // future: 'generate_pdf_invoice' => Handlers\GeneratePdfInvoiceHandler::class,
         // future: 'sync_channel_inventory' => Handlers\SyncChannelInventoryHandler::class,

--- a/database/migrations/020_channel_health_monitor.sql
+++ b/database/migrations/020_channel_health_monitor.sql
@@ -1,0 +1,110 @@
+-- =========================================================================
+-- Migration 020: Channel Health Monitor (v6.2 / issue #83)
+-- =========================================================================
+-- Tables for the v6.2 Channel Health Monitor — periodic heartbeat against
+-- LINE OA, Sales Channel API, outbound webhook system, and email SMTP, plus
+-- alert state machine for downtime > 5 consecutive failures.
+--
+-- Idempotent — safe to run twice. CREATE TABLE IF NOT EXISTS is enough since
+-- this migration only adds new tables; no ALTERs on existing tables.
+--
+-- Date: 2026-05-05
+-- Run (local):     docker exec -i iacc_mysql mysql -uroot -proot iacc < database/migrations/020_channel_health_monitor.sql
+-- Run (cPanel):    phpMyAdmin → Import → 020_channel_health_monitor.sql
+-- =========================================================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. channel_health_log — One row per heartbeat tick per channel
+-- ─────────────────────────────────────────────────────────────────────────
+-- Volume estimate: 213 companies × ~4 channels × 12 ticks/hr × 24h ≈ 245k rows/day.
+-- 30-day retention (cleaned up by daily cron worker — see v6.3 #92) ≈ 7.4M rows.
+-- BIGINT UNSIGNED PK to match task_queue pattern for high-volume queue/log tables.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS `channel_health_log` (
+    `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT          COMMENT 'High-volume log; BIGINT to avoid future overflow',
+    `company_id`    INT(11) NOT NULL                                  COMMENT 'FK company.id — multi-tenant scope',
+    `channel_type`  ENUM('line_oa','sales_channel_api','outbound_webhook','email_smtp')
+                    NOT NULL                                          COMMENT 'Discriminator for which subsystem was checked',
+    `channel_ref`   VARCHAR(255) DEFAULT NULL                         COMMENT 'Channel-specific identifier (webhook URL, LINE channel id, etc.)',
+    `status`        ENUM('success','failure','not_configured')
+                    NOT NULL                                          COMMENT 'Heartbeat outcome',
+    `response_ms`   INT UNSIGNED DEFAULT NULL                         COMMENT 'Wall-clock latency of the check; NULL when not_configured',
+    `error_message` VARCHAR(1024) DEFAULT NULL                        COMMENT 'Truncated error from the failed call (raw is not stored — too noisy)',
+    `checked_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP      COMMENT 'When this heartbeat fired; primary timeline column',
+    `created_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP      COMMENT 'Row insert time (= checked_at, kept for codebase convention)',
+    PRIMARY KEY (`id`),
+    KEY `idx_dashboard`     (`company_id`, `channel_type`, `checked_at`)  COMMENT 'Per-tenant dashboard: status grid + 24h chart',
+    KEY `idx_recent_status` (`company_id`, `checked_at`)                  COMMENT 'Cross-channel "last 100" timeline',
+    KEY `idx_retention`     (`checked_at`)                                COMMENT 'Daily retention cleanup (delete WHERE checked_at < NOW() - INTERVAL 30 DAY)'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-heartbeat log for v6.2 Channel Health Monitor (#83). High-volume; 30-day retention.';
+
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. channel_alerts — Alert state machine, opened on 5+ consecutive failures
+-- ─────────────────────────────────────────────────────────────────────────
+-- One row per (company, channel, downtime episode). Auto-resolves when channel
+-- comes back up. Email is sent on transitions (open and resolved), not on
+-- sustained downtime — alert_email_sent_count caps at 2 per row.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS `channel_alerts` (
+    `id`                     INT(11) NOT NULL AUTO_INCREMENT,
+    `company_id`             INT(11) NOT NULL                              COMMENT 'FK company.id',
+    `channel_type`           VARCHAR(50) NOT NULL                          COMMENT 'Same enum values as channel_health_log; VARCHAR to allow future channels without ALTER',
+    `channel_ref`            VARCHAR(255) DEFAULT NULL                     COMMENT 'Optional channel-specific identifier (matches channel_health_log)',
+    `status`                 ENUM('open','acknowledged','resolved')
+                             NOT NULL DEFAULT 'open'                       COMMENT 'open=active downtime; acknowledged=admin saw it; resolved=channel back up',
+    `opened_at`              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP  COMMENT 'When the 5th consecutive failure occurred',
+    `acknowledged_at`        TIMESTAMP NULL DEFAULT NULL                   COMMENT 'When admin clicked Acknowledge (suppresses repeat alerts)',
+    `acknowledged_by`        INT(11) DEFAULT NULL                          COMMENT 'FK user.usr_id of acknowledger',
+    `resolved_at`            TIMESTAMP NULL DEFAULT NULL                   COMMENT 'When the channel became healthy again',
+    `last_error`             VARCHAR(1024) DEFAULT NULL                    COMMENT 'Most recent error message at time of alert (debugging aid)',
+    `alert_email_sent_count` SMALLINT UNSIGNED NOT NULL DEFAULT 0          COMMENT 'Increment on each email send; cap at 2 (open + resolved)',
+    `created_at`             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                             ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `idx_open_alerts`    (`company_id`, `status`, `channel_type`)      COMMENT 'Dashboard "open alerts" panel + per-channel state lookup',
+    KEY `idx_active_episode` (`company_id`, `channel_type`, `status`, `opened_at`)
+                                                                          COMMENT 'Find the currently-open alert for (company, channel) on heartbeat eval'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Alert state machine for v6.2 Channel Health Monitor (#83). One row per downtime episode.';
+
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. Log this migration in _migration_log (idempotent UPSERT)
+-- ─────────────────────────────────────────────────────────────────────────
+-- Uses ON DUPLICATE KEY to handle re-runs cleanly. Column names match the
+-- production _migration_log schema verified on 2026-05-04 (executed_at, status).
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO `_migration_log` (`migration_name`, `status`, `notes`)
+VALUES (
+    '020_channel_health_monitor',
+    'success',
+    'v6.2 #83: created channel_health_log + channel_alerts tables. No ALTERs.'
+)
+ON DUPLICATE KEY UPDATE
+    `executed_at` = CURRENT_TIMESTAMP,
+    `status`      = 'success',
+    `notes`       = VALUES(`notes`);
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- =========================================================================
+-- Verification queries (run manually after import to confirm)
+-- =========================================================================
+-- SELECT
+--   (SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='channel_health_log') AS log_table_exists,
+--   (SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='channel_alerts')     AS alerts_table_exists,
+--   (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name='channel_health_log') AS log_indexes,
+--   (SELECT migration_name FROM _migration_log WHERE migration_name='020_channel_health_monitor' ORDER BY executed_at DESC LIMIT 1) AS logged;
+-- Expected: log_table_exists=1, alerts_table_exists=1, log_indexes>=4, logged='020_channel_health_monitor'
+
+-- =========================================================================
+-- ROLLBACK (manual — only run if you know what you're doing)
+-- =========================================================================
+-- DROP TABLE IF EXISTS `channel_alerts`;
+-- DROP TABLE IF EXISTS `channel_health_log`;
+-- DELETE FROM `_migration_log` WHERE `migration_name`='020_channel_health_monitor';

--- a/inc/string-th.xml
+++ b/inc/string-th.xml
@@ -347,6 +347,7 @@
 <apikeys>คีย์ API</apikeys>
 <apisubscriptions>สมัครสมาชิก API</apisubscriptions>
 <apiwebhooks>เว็บฮุค API</apiwebhooks>
+<channelhealth>สถานะช่องทาง</channelhealth>
 <apiusagelogs>บันทึกการใช้งาน API</apiusagelogs>
 <apiorders>คำสั่งซื้อ API</apiorders>
 <apiinvoices>ใบแจ้งหนี้ API</apiinvoices>

--- a/inc/string-us.xml
+++ b/inc/string-us.xml
@@ -347,6 +347,7 @@
 <apikeys>API Keys</apikeys>
 <apisubscriptions>API Subscriptions</apisubscriptions>
 <apiwebhooks>API Webhooks</apiwebhooks>
+<channelhealth>Channel Health</channelhealth>
 <apiusagelogs>API Usage Logs</apiusagelogs>
 <apiorders>API Orders</apiorders>
 <apiinvoices>API Invoices</apiinvoices>


### PR DESCRIPTION
## Release: v6.2 #83 Channel Health Monitor → production

Sync `develop → main` for v6.2 Channel Health Monitor (issue #83). Five commits, all already verified on staging.

## What ships

| Component | Files | Verified on staging |
|---|---|---|
| **Migration** — adds `channel_health_log` + `channel_alerts` (BIGINT log table for high-volume heartbeat data, INT alerts table for state machine) | `database/migrations/020_channel_health_monitor.sql` | ✅ idempotent, ran twice on iacc + staging |
| **Models** — `ChannelHealthLog` (insert + dashboard reads + 30-day prune) and `ChannelAlert` (state machine: open → acknowledged → resolved) | `app/Models/ChannelHealthLog.php`, `app/Models/ChannelAlert.php` | ✅ |
| **Worker handler** — probes 4 channels per tick, evaluates 5-failure threshold, opens/resolves alerts, self-reschedules at +5min | `app/Workers/Handlers/ChannelHeartbeatHandler.php` (registered in `WorkerRunner::HANDLERS`) | ✅ runs on staging cron, real LINE API probes confirmed |
| **Probers** (real, not stubs) — LINE OA via `/v2/bot/info`, Sales Channel API via loopback `/?page=health`, outbound webhook via `api_webhook_deliveries` telemetry, email SMTP via TCP fsockopen | (in handler) | ✅ all 4 verified end-to-end |
| **Email alerter** — bilingual TH/EN HTML+text, sends to admin recipients from `authorize` table on `opened` and `resolved` transitions only (capped at 2/episode) | `EmailService` integration | ✅ doesn't crash when SMTP unconfigured |
| **Controller** — admin dashboard view + AJAX `testNow` (30s rate-limit) + AJAX `acknowledge` (CSRF + tenant check) | `app/Controllers/ChannelHealthController.php` | ✅ |
| **Frontend** — main dashboard + status card partial + alert row partial + Chart.js 24h chart, fully bilingual TH/EN, mobile-friendly @ 768px / 540px | `app/Views/admin/channel-health/{index,_status_card,_alert_row}.php` | ✅ status grid + chart + timeline all rendered live |
| **Sidebar entry** — under Sales Channel, admin-only (level ≥ 2), bilingual via XML | `app/Views/layouts/sidebar.php`, `inc/string-{us,th}.xml` | ✅ |
| **Routes** — `channel_health`, `channel_health_test_now`, `channel_health_acknowledge` | `app/Config/routes.php` | ✅ |

## Production deploy runbook

After this PR merges (`🚀 Deploy to Production` workflow auto-fires):

1. **Apply migration** in production phpMyAdmin (`f2coth_iacc_saas`) → Import → `database/migrations/020_channel_health_monitor.sql`
2. **Verify schema**:
   ```sql
   SHOW TABLES LIKE 'channel_health_log';
   SHOW TABLES LIKE 'channel_alerts';
   ```
3. **Seed first heartbeat task** for the tenant you want to monitor:
   ```sql
   INSERT INTO task_queue (company_id, task_type, payload, priority, status, scheduled_for)
   VALUES (
       <production_company_id>,
       'channel_heartbeat',
       JSON_OBJECT('triggered_by', 'production_seed'),
       1, 'pending', NOW()
   );
   ```
4. **Verify production cron is `* * * * *`** (currently `*/24` — fix in cPanel cron entry before deploying ANY background work in production)
5. Browser: `https://iacc.f2.co.th/?page=channel_health` → dashboard renders, status cards populate within 5 minutes

## What's strictly additive (zero risk to accounting core)

- ❌ ZERO `ALTER` on existing tables (`tour_bookings`, `invoice`, `journal_entries`, `agent_contracts`, `company`, etc.)
- ❌ ZERO migrations to existing schema
- ✅ Adds 2 new tables only
- ✅ Adds 1 new task_type to `WorkerRunner::HANDLERS` (extends without modifying existing types)

Worst-case rollback: revert the merge commit + `DROP TABLE channel_health_log; DROP TABLE channel_alerts;`. Existing data unaffected.

## Out of scope (deferred to v6.2 sprint 2 / 3)

- ❌ FB Messenger / inbound email channels (those services don't exist yet — added when channel integration ships)
- ❌ Webhook auto-retry on failure (v6.3 #90)
- ❌ SMS / Slack alerts (email only for MVP)
- ❌ Cross-tenant super-admin view
- ❌ Historical uptime % reporting
- ❌ Issues #82 / #79 / #80 — separate sprints per Option B

## Test plan

- [ ] Auto-deploy to production via `🚀 Deploy to Production` succeeds
- [ ] Production site loads (`HTTP 200` on `/?page=login`)
- [ ] Migration applied via phpMyAdmin (steps 1-2 above)
- [ ] Production cron schedule fixed to `* * * * *` BEFORE seeding (step 4)
- [ ] Heartbeat task seeded → drains within 60s on first tick
- [ ] Sidebar shows "Channel Health" entry under Sales Channel for admin users
- [ ] Browser: dashboard renders all 4 status cards, alerts panel, chart, timeline
- [ ] No regression in existing tour booking / payment / contract flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
