### PR TITLE
chore(tracker): close v6.2 #83 — version bump + roadmap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # iACC - Accounting Management System
 
-**Version**: 6.1-task-queue-workers  
+**Version**: 6.2-channel-health-monitor  
 **Status**: Production Ready  
-**Last Updated**: May 4, 2026  
+**Last Updated**: May 5, 2026  
 **Architecture**: MVC (Model-View-Controller) + REST API  
 **PHP**: 8.2+ | **MySQL**: 5.7 | **Nginx**: Alpine
 
@@ -609,7 +609,7 @@ docker exec iacc_php php /var/www/html/tests/test-mvc-comprehensive.php
 |---|---------|---------|---------|---------------|--------------|
 | 1 | **v6.0** | Self-Registration → Trial → Payment | Q4 2026 | [milestone open](https://github.com/psinthorn/iacc-php-mvc/milestone/12) — 4 closed / 5 open | None |
 | 2 | **v6.1** | Task Queue & Background Worker Infrastructure | Q2 2026 | ✅ **shipped 2026-05-04** ([milestone v6.1](https://github.com/psinthorn/iacc-php-mvc/milestone/14)) — 4 issues closed via [PR #94](https://github.com/psinthorn/iacc-php-mvc/pull/94) | v6.0 |
-| 3 | **v6.2** | AI-Powered Sales Channel Automation | Q1 2027 | [milestone open](https://github.com/psinthorn/iacc-php-mvc/milestone/15) — 6 skeleton issues filed | v6.1 + Sales Channel API |
+| 3 | **v6.2** | AI-Powered Sales Channel Automation | Q1 2027 | 🚧 **in progress** — 1 / 6 shipped ([milestone v6.2](https://github.com/psinthorn/iacc-php-mvc/milestone/15)). #83 Channel Health Monitor live 2026-05-05 ([PR #100](https://github.com/psinthorn/iacc-php-mvc/pull/100)) | v6.1 + Sales Channel API |
 | 4 | **v6.3** | Agent Automation Workers | Q1 2027 | [milestone open](https://github.com/psinthorn/iacc-php-mvc/milestone/16) — 8 skeleton issues filed | v6.1 |
 | 5 | **v6.4** | AI Document Processing (OCR) | Q2 2027 | _no milestone yet — text-only roadmap_ | v6.1 |
 | 6 | **v6.5** | Conversational BI & Smart Insights | Q2 2027 | _no milestone yet — text-only roadmap_ | Existing AI (29 tools) |
@@ -643,16 +643,18 @@ docker exec iacc_php php /var/www/html/tests/test-mvc-comprehensive.php
 
 **Operational notes:** Cron contract is `cron.php?task=run_worker&token=$CRON_TOKEN_PRODUCTION` every minute. cPanel job uses `/usr/bin/curl` (NOT `/usr/local/bin/curl` — host-specific path). Worker processes ≤ 1 task per tick, ceiling ≈ 1,440/day per server.
 
-### v6.2 — AI-Powered Sales Channel Automation
+### v6.2 — AI-Powered Sales Channel Automation 🚧 1 of 6 shipped
 
-📋 **GitHub:** [milestone v6.2](https://github.com/psinthorn/iacc-php-mvc/milestone/15) — 6 skeleton issues filed
+📋 **GitHub:** [milestone v6.2](https://github.com/psinthorn/iacc-php-mvc/milestone/15) · sprint-1 in progress per [Option B](https://github.com/psinthorn/iacc-php-mvc/pull/100) (LINE-only MVP for AI features; #81 + #84 deferred to v6.3)
 
 - [#79](https://github.com/psinthorn/iacc-php-mvc/issues/79) **AI Order Parser** — LINE/Facebook/email → structured `channel_orders`
 - [#80](https://github.com/psinthorn/iacc-php-mvc/issues/80) **Smart Order Router** — classify orders by channel + content
-- [#81](https://github.com/psinthorn/iacc-php-mvc/issues/81) **AI Price Optimizer** — dynamic pricing per channel (weekend/season/margin)
-- [#82](https://github.com/psinthorn/iacc-php-mvc/issues/82) **Inventory Sync Worker** — iACC products ↔ external channels
-- [#83](https://github.com/psinthorn/iacc-php-mvc/issues/83) **Channel Health Monitor** — API health checks + webhook delivery alerts
-- [#84](https://github.com/psinthorn/iacc-php-mvc/issues/84) **AI Response Generator** — auto-reply with catalog + availability
+- [#81](https://github.com/psinthorn/iacc-php-mvc/issues/81) **AI Price Optimizer** — dynamic pricing per channel (weekend/season/margin) — _deferred to v6.3_
+- [#82](https://github.com/psinthorn/iacc-php-mvc/issues/82) **Inventory Sync Worker** — iACC products ↔ external channels — _next sprint_
+- [#83](https://github.com/psinthorn/iacc-php-mvc/issues/83) **Channel Health Monitor** — API health checks + webhook delivery alerts — _shipped 2026-05-05 ([PR #100](https://github.com/psinthorn/iacc-php-mvc/pull/100))_
+- [#84](https://github.com/psinthorn/iacc-php-mvc/issues/84) **AI Response Generator** — auto-reply with catalog + availability — _deferred to v6.3_
+
+**#83 — what shipped:** Periodic heartbeat (every minute via v6.1 task queue) probing 4 channels per tenant — LINE OA (`/v2/bot/info`), Sales Channel API (loopback), outbound webhook (passive telemetry from `api_webhook_deliveries`), email SMTP (TCP probe). Alerts open after 5 consecutive failures, auto-resolve on first success, bilingual TH/EN email notifications to admins (capped at 2 per downtime episode). Admin dashboard at `/?page=channel_health` with status grid, 24h response chart (Chart.js), open-alerts panel, last-100 timeline. New tables: `channel_health_log` (BIGINT PK, 30-day retention) + `channel_alerts` (state machine).
 
 ### v6.3 — Agent Automation Workers
 

--- a/version.json
+++ b/version.json
@@ -1,9 +1,9 @@
 {
-  "version": "6.1-task-queue-workers",
-  "commit": "711702c",
-  "commit_short": "711702c",
+  "version": "6.2-channel-health-monitor",
+  "commit": "0433576",
+  "commit_short": "0433576",
   "branch": "main",
-  "build_date": "2026-05-04T15:20:00+07:00",
+  "build_date": "2026-05-05T15:01:00+07:00",
   "environment": "production",
   "deployed_by": "manual"
 }


### PR DESCRIPTION
Tracker post-merge bump for #83 Channel Health Monitor (PR #100, merged 2026-05-05).

- version.json → 6.2-channel-health-monitor (commit 0433576)
- README header → version 6.2, last-updated 2026-05-05
- README roadmap row v6.2 → "in progress — 1/6 shipped"
- README v6.2 detail → #83 marked shipped, sprint plan annotated per Option B

Will close GitHub issue #83 after this PR merges.