### PR TITLE
fix(v6.2): ambiguous created_at in ChannelHeartbeatHandler::probeOutboundWebhook

### DIFF
--- a/app/Workers/Handlers/ChannelHeartbeatHandler.php
+++ b/app/Workers/Handlers/ChannelHeartbeatHandler.php
@@ -218,10 +218,13 @@ class ChannelHeartbeatHandler implements TaskHandler
             return ['status' => ChannelHealthLog::STATUS_NOT_CONFIGURED];
         }
 
+        // Qualify created_at and error with table aliases — both api_webhook_deliveries
+        // and api_webhooks have a created_at column, so unqualified references throw
+        // "Column 'created_at' in field list is ambiguous".
         $statsSql = "SELECT
-                        SUM(success)                            AS ok_count,
-                        COUNT(*)                                AS total,
-                        SUBSTRING_INDEX(GROUP_CONCAT(error ORDER BY created_at DESC), ',', 1) AS last_error
+                        SUM(d.success)                              AS ok_count,
+                        COUNT(*)                                    AS total,
+                        SUBSTRING_INDEX(GROUP_CONCAT(d.error ORDER BY d.created_at DESC), ',', 1) AS last_error
                       FROM api_webhook_deliveries d
                       JOIN api_webhooks w ON w.id = d.webhook_id
                      WHERE w.company_id = $companyId


### PR DESCRIPTION
Caught while QA-ing #82 on staging.

`ChannelHeartbeatHandler::probeOutboundWebhook` joins `api_webhook_deliveries` to `api_webhooks` — both have a `created_at` column. Unqualified column refs inside the SELECT throw:

```
mysqli_sql_exception: Column 'created_at' in field list is ambiguous
```

The bug shipped silently in PR #99 (#83 Phase 4.5) — only triggers when a tenant has both an active `api_webhooks` row AND recent rows in `api_webhook_deliveries` (< 30 min old). Most tenants on staging didn't until I created one for the #82 webhook test.

**Fix:** qualify all column refs with the `d` alias.

Tested locally — error gone, query returns expected aggregate.