### PR TITLE
feat(v6.3): LINE OA rich messaging — probe, templates, broadcasts

### DIFF
--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -248,6 +248,15 @@ return [
     'line_auto_replies'  => ['LineOAController', 'autoReplies'],
     'line_webhook_log'   => ['LineOAController', 'webhookLog'],
     'line_send_message'  => ['LineOAController', 'sendMessagePage'],
+    // v6.3 — rich messaging
+    'line_probe'                  => ['LineOAController', 'probeConnection'],
+    'line_templates'              => ['LineOAController', 'templates'],
+    'line_template_edit'          => ['LineOAController', 'templateEdit'],
+    'line_template_save'          => ['LineOAController', 'templateSave'],
+    'line_broadcasts'             => ['LineOAController', 'broadcasts'],
+    'line_broadcast_compose'      => ['LineOAController', 'broadcastCompose'],
+    'line_broadcast_save'         => ['LineOAController', 'broadcastSave'],
+    'line_broadcast_audience_count' => ['LineOAController', 'broadcastAudienceCount'],
 
     // ========== Pre-Auth Routes (no login required, standalone HTML) ==========
     'authorize'              => ['AuthController', 'authenticate', 'public'],

--- a/app/Controllers/LineOAController.php
+++ b/app/Controllers/LineOAController.php
@@ -18,11 +18,362 @@ namespace App\Controllers;
 class LineOAController extends BaseController
 {
     private \App\Models\LineOA $lineModel;
+    private \App\Models\LineMessaging $msgModel;
 
     public function __construct()
     {
         parent::__construct();
         $this->lineModel = new \App\Models\LineOA();
+        $this->msgModel  = new \App\Models\LineMessaging();
+    }
+
+    // ====================================================================
+    // v6.3 — Health Probe
+    // ====================================================================
+
+    /**
+     * AJAX endpoint: re-probe LINE channel and return JSON status.
+     * Also persists the latest result to line_oa_config for the dashboard cache.
+     */
+    public function probeConnection(): void
+    {
+        header('Content-Type: application/json');
+        $companyId = (int)$this->user['com_id'];
+        $config = $this->lineModel->getConfig($companyId);
+
+        if (!$config || empty($config['channel_access_token'])) {
+            echo json_encode(['status' => 'unknown', 'error' => 'No credentials configured']);
+            return;
+        }
+
+        $service = new \App\Services\LineService(
+            (string)$config['channel_access_token'],
+            (string)$config['channel_secret']
+        );
+        $probe = $service->probeChannel();
+        $this->lineModel->updateProbeResult($companyId, $probe);
+
+        echo json_encode([
+            'status'       => $probe['status'],
+            'display_name' => $probe['display_name'] ?? null,
+            'picture_url'  => $probe['picture_url']  ?? null,
+            'basic_id'     => $probe['basic_id']     ?? null,
+            'error'        => $probe['error']        ?? null,
+            'probed_at'    => date('c'),
+        ]);
+    }
+
+    // ====================================================================
+    // v6.3 — Templates
+    // ====================================================================
+
+    public function templates(): void
+    {
+        $companyId = (int)$this->user['com_id'];
+        $templates = $this->msgModel->getTemplates($companyId);
+        $this->render('line-oa/templates-index', ['templates' => $templates]);
+    }
+
+    public function templateEdit(): void
+    {
+        $companyId = (int)$this->user['com_id'];
+        $id = (int)($_GET['id'] ?? 0);
+        $template = $id ? $this->msgModel->getTemplate($id, $companyId) : null;
+
+        if ($id && !$template) {
+            $_SESSION['flash_error'] = 'Template not found.';
+            $this->redirect('line_templates');
+            return;
+        }
+
+        $this->render('line-oa/template-edit', ['template' => $template]);
+    }
+
+    public function templateSave(): void
+    {
+        $this->verifyCsrf();
+        $companyId = (int)$this->user['com_id'];
+        $userId    = (int)($this->user['id'] ?? 0);
+
+        $action = $_POST['action'] ?? 'save';
+        if ($action === 'delete') {
+            $id = (int)($_POST['id'] ?? 0);
+            if ($id) $this->msgModel->deleteTemplate($id, $companyId);
+            $_SESSION['flash_success'] = 'Template deleted.';
+            $this->redirect('line_templates');
+            return;
+        }
+
+        $data = [
+            'id'             => (int)($_POST['id'] ?? 0),
+            'name'           => trim($_POST['name'] ?? ''),
+            'template_type'  => $_POST['template_type'] ?? 'custom',
+            'message_type'   => $_POST['message_type'] ?? 'flex',
+            'alt_text'       => trim($_POST['alt_text'] ?? ''),
+            'content_th'     => $_POST['content_th'] ?? null,
+            'content_en'     => $_POST['content_en'] ?? null,
+            'variables_json' => $_POST['variables_json'] ?? null,
+            'is_active'      => (int)($_POST['is_active'] ?? 1),
+        ];
+        if ($data['name'] === '') {
+            $_SESSION['flash_error'] = 'Template name is required.';
+            $this->redirect('line_template_edit' . ($data['id'] ? '&id=' . $data['id'] : ''));
+            return;
+        }
+
+        $this->msgModel->saveTemplate($companyId, $data, $userId);
+        $_SESSION['flash_success'] = 'Template saved.';
+        $this->redirect('line_templates');
+    }
+
+    // ====================================================================
+    // v6.3 — Broadcasts
+    // ====================================================================
+
+    public function broadcasts(): void
+    {
+        $companyId = (int)$this->user['com_id'];
+        $broadcasts = $this->msgModel->getBroadcasts($companyId);
+        $config = $this->lineModel->getConfig($companyId);
+        $quotaUsed = $this->msgModel->getMonthlyBroadcastUsage($companyId);
+        $quotaLimit = (int)($config['broadcast_quota_monthly'] ?? 500);
+        $this->render('line-oa/broadcasts-index', [
+            'broadcasts'  => $broadcasts,
+            'quota_used'  => $quotaUsed,
+            'quota_limit' => $quotaLimit,
+        ]);
+    }
+
+    public function broadcastCompose(): void
+    {
+        $companyId = (int)$this->user['com_id'];
+        $id = (int)($_GET['id'] ?? 0);
+        $broadcast = $id ? $this->msgModel->getBroadcast($id, $companyId) : null;
+        if ($id && !$broadcast) {
+            $_SESSION['flash_error'] = 'Broadcast not found.';
+            $this->redirect('line_broadcasts');
+            return;
+        }
+        // sent broadcasts = read-only
+        if ($broadcast && in_array($broadcast['status'], ['sent','sending','partial'])) {
+            $this->render('line-oa/broadcast-view', ['broadcast' => $broadcast]);
+            return;
+        }
+        $templates = $this->msgModel->getTemplates($companyId, true);
+        $tags      = $this->msgModel->getTags($companyId);
+        $this->render('line-oa/broadcast-compose', [
+            'broadcast' => $broadcast,
+            'templates' => $templates,
+            'tags'      => $tags,
+        ]);
+    }
+
+    /**
+     * AJAX: return audience count for the given filter.
+     */
+    public function broadcastAudienceCount(): void
+    {
+        header('Content-Type: application/json');
+        $companyId = (int)$this->user['com_id'];
+        $type   = $_GET['audience_type'] ?? 'all';
+        $filter = json_decode($_GET['filter'] ?? '{}', true) ?: [];
+        $count  = $this->msgModel->audienceCount($companyId, $type, $filter);
+        echo json_encode(['count' => $count]);
+    }
+
+    public function broadcastSave(): void
+    {
+        $this->verifyCsrf();
+        $companyId = (int)$this->user['com_id'];
+        $userId    = (int)($this->user['id'] ?? 0);
+        $action    = $_POST['action'] ?? 'save_draft';
+
+        $filter = $_POST['audience_filter'] ?? [];
+        $data = [
+            'id'                   => (int)($_POST['id'] ?? 0),
+            'name'                 => trim($_POST['name'] ?? ''),
+            'audience_type'        => $_POST['audience_type'] ?? 'all',
+            'audience_filter_json' => json_encode($filter),
+            'message_kind'         => $_POST['message_kind'] ?? 'text',
+            'template_id'          => !empty($_POST['template_id']) ? (int)$_POST['template_id'] : null,
+            'text_content_th'      => $_POST['text_content_th'] ?? null,
+            'text_content_en'      => $_POST['text_content_en'] ?? null,
+            'flex_content_th'      => $_POST['flex_content_th'] ?? null,
+            'flex_content_en'      => $_POST['flex_content_en'] ?? null,
+            'alt_text'             => trim($_POST['alt_text'] ?? ''),
+            'scheduled_at'         => trim($_POST['scheduled_at'] ?? '') ?: null,
+            'status'               => 'draft',
+        ];
+        if ($data['name'] === '') {
+            $_SESSION['flash_error'] = 'Name is required.';
+            $this->redirect('line_broadcast_compose');
+            return;
+        }
+
+        // Enforce monthly broadcast quota — block send_now/schedule when used + audience > limit.
+        // Drafts are always allowed (no messages sent yet).
+        if ($action !== 'save_draft') {
+            $config     = $this->lineModel->getConfig($companyId);
+            $quotaLimit = (int)($config['broadcast_quota_monthly'] ?? 500);
+            $quotaUsed  = $this->msgModel->getMonthlyBroadcastUsage($companyId);
+            $audienceN  = $this->msgModel->audienceCount($companyId, $data['audience_type'], $filter);
+            if (($quotaUsed + $audienceN) > $quotaLimit) {
+                $_SESSION['flash_error'] = sprintf(
+                    'Quota exceeded: %d used this month + %d this send would exceed %d limit. Save as draft or reduce audience.',
+                    $quotaUsed, $audienceN, $quotaLimit
+                );
+                $this->redirect('line_broadcast_compose');
+                return;
+            }
+        }
+
+        if ($action === 'send_now') {
+            $data['status'] = 'sending';
+        } elseif ($action === 'schedule') {
+            if (!$data['scheduled_at']) {
+                $_SESSION['flash_error'] = 'Scheduled time is required.';
+                $this->redirect('line_broadcast_compose');
+                return;
+            }
+            $data['status'] = 'scheduled';
+        }
+
+        $id = $this->msgModel->saveBroadcast($companyId, $data, $userId);
+
+        if ($action === 'send_now') {
+            $this->msgModel->materializeRecipients($id, $companyId);
+            $result = $this->dispatchBroadcast($id, $companyId);
+            $_SESSION['flash_success'] = 'Broadcast sent: ' . ($result['sent'] ?? 0) .
+                                         ' delivered, ' . ($result['failed'] ?? 0) . ' failed.';
+        } elseif ($action === 'schedule') {
+            $this->msgModel->materializeRecipients($id, $companyId);
+            $_SESSION['flash_success'] = 'Broadcast scheduled.';
+        } else {
+            $_SESSION['flash_success'] = 'Draft saved.';
+        }
+        $this->redirect('line_broadcasts');
+    }
+
+    /**
+     * Materialize-then-multicast loop. Idempotent: only picks up rows still in 'pending'.
+     * Used both by send-now and the cron worker.
+     */
+    public function dispatchBroadcast(int $broadcastId, int $companyId): array
+    {
+        $b = $this->msgModel->getBroadcast($broadcastId, $companyId);
+        if (!$b) return ['sent' => 0, 'failed' => 0, 'error' => 'Broadcast not found'];
+
+        $config = $this->lineModel->getConfig($companyId);
+        if (!$config || empty($config['channel_access_token'])) {
+            $this->msgModel->updateBroadcastStatus($broadcastId, $companyId, 'failed',
+                ['last_error' => 'No LINE credentials']);
+            return ['sent' => 0, 'failed' => 0, 'error' => 'No credentials'];
+        }
+
+        $this->msgModel->updateBroadcastStatus($broadcastId, $companyId, 'sending', ['mark_started' => true]);
+
+        $service = new \App\Services\LineService(
+            (string)$config['channel_access_token'],
+            (string)$config['channel_secret']
+        );
+
+        $messages = $this->buildBroadcastMessages($b, $companyId);
+        if (empty($messages)) {
+            $this->msgModel->updateBroadcastStatus($broadcastId, $companyId, 'failed',
+                ['last_error' => 'Empty message payload']);
+            return ['sent' => 0, 'failed' => 0, 'error' => 'Empty message'];
+        }
+
+        $totalSent = 0;
+        $totalFailed = 0;
+        $lastError = null;
+
+        // Drain pending recipients in chunks of 500 (LINE multicast limit)
+        while (true) {
+            $chunk = $this->msgModel->getPendingRecipientChunk($broadcastId, $companyId, 500);
+            if (empty($chunk)) break;
+
+            $userIds = array_column($chunk, 'line_user_id');
+            $rowIds  = array_column($chunk, 'recipient_row_id');
+            $resp = $service->multicast($userIds, $messages);
+
+            if ($resp['success'] ?? false) {
+                $this->msgModel->markRecipientsSent($rowIds, $companyId);
+                $totalSent += count($rowIds);
+            } else {
+                $err = $resp['message'] ?? ($resp['error'] ?? 'Unknown error');
+                $this->msgModel->markRecipientsFailed($rowIds, $companyId, $err);
+                $totalFailed += count($rowIds);
+                $lastError = $err;
+                // Stop on auth errors — no point retrying
+                if (in_array((int)($resp['http_code'] ?? 0), [401, 403])) break;
+            }
+        }
+
+        $finalStatus = $totalFailed === 0 ? 'sent' : ($totalSent > 0 ? 'partial' : 'failed');
+        $this->msgModel->updateBroadcastStatus($broadcastId, $companyId, $finalStatus, [
+            'sent_count'     => $totalSent,
+            'failed_count'   => $totalFailed,
+            'last_error'     => $lastError,
+            'mark_completed' => true,
+        ]);
+
+        return ['sent' => $totalSent, 'failed' => $totalFailed, 'error' => $lastError];
+    }
+
+    /**
+     * Pick the right message payload (text vs template vs custom flex) and language.
+     * For broadcasts we don't know per-recipient language, so we use the company default.
+     */
+    private function buildBroadcastMessages(array $broadcast, int $companyId): array
+    {
+        $isThai = (($_SESSION['lang'] ?? '0') === '1');
+
+        switch ($broadcast['message_kind']) {
+            case 'template':
+                $tpl = $this->msgModel->getTemplate((int)$broadcast['template_id'], $companyId);
+                if (!$tpl) return [];
+                $rendered = $this->msgModel->renderTemplate($tpl, [], $isThai);
+                if ($rendered['type'] === 'text') {
+                    return [['type' => 'text', 'text' => $rendered['text']]];
+                }
+                return [['type' => 'flex', 'altText' => $rendered['alt_text'] ?: 'Message', 'contents' => $rendered['contents']]];
+
+            case 'custom_flex':
+                $flexJson = $isThai
+                    ? ($broadcast['flex_content_th'] ?? $broadcast['flex_content_en'])
+                    : ($broadcast['flex_content_en'] ?? $broadcast['flex_content_th']);
+                $contents = json_decode((string)$flexJson, true);
+                if (!$contents) return [];
+                return [['type' => 'flex', 'altText' => $broadcast['alt_text'] ?: 'Message', 'contents' => $contents]];
+
+            case 'text':
+            default:
+                $text = $isThai
+                    ? ($broadcast['text_content_th'] ?? $broadcast['text_content_en'])
+                    : ($broadcast['text_content_en'] ?? $broadcast['text_content_th']);
+                if (empty($text)) return [];
+                return [['type' => 'text', 'text' => (string)$text]];
+        }
+    }
+
+    /**
+     * Cron entrypoint: process all due scheduled broadcasts across tenants.
+     * Called from cron.php only — never via web routing.
+     */
+    public function processDueBroadcasts(): array
+    {
+        $due = $this->msgModel->findDueBroadcasts(20);
+        $report = ['processed' => 0, 'sent' => 0, 'failed' => 0, 'broadcasts' => []];
+        foreach ($due as $b) {
+            $companyId = (int)$b['company_id'];
+            $result = $this->dispatchBroadcast((int)$b['id'], $companyId);
+            $report['processed']++;
+            $report['sent']    += $result['sent']   ?? 0;
+            $report['failed']  += $result['failed'] ?? 0;
+            $report['broadcasts'][] = ['id' => $b['id'], 'company_id' => $companyId] + $result;
+        }
+        return $report;
     }
 
     /**

--- a/app/Models/LineMessaging.php
+++ b/app/Models/LineMessaging.php
@@ -1,0 +1,518 @@
+<?php
+namespace App\Models;
+
+/**
+ * LineMessaging — v6.3 rich messaging operations
+ *
+ * Tables:
+ * - line_message_templates: bilingual Flex/text templates per company
+ * - line_broadcasts: campaign records
+ * - line_broadcast_recipients: per-user delivery rows
+ * - line_user_tags + line_user_tag_map: segmentation
+ *
+ * All queries are prepared statements and filter by company_id.
+ */
+class LineMessaging extends BaseModel
+{
+    // ====================================================================
+    // Templates
+    // ====================================================================
+
+    public function getTemplates(int $companyId, bool $activeOnly = false): array
+    {
+        $sql = "SELECT * FROM line_message_templates WHERE company_id = ? AND deleted_at IS NULL";
+        if ($activeOnly) $sql .= " AND is_active = 1";
+        $sql .= " ORDER BY template_type, name";
+        $stmt = $this->conn->prepare($sql);
+        $stmt->bind_param('i', $companyId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    public function getTemplate(int $id, int $companyId): ?array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT * FROM line_message_templates WHERE id = ? AND company_id = ? AND deleted_at IS NULL"
+        );
+        $stmt->bind_param('ii', $id, $companyId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ?: null;
+    }
+
+    public function saveTemplate(int $companyId, array $data, ?int $userId = null): int
+    {
+        $id           = (int)($data['id'] ?? 0);
+        $name         = trim($data['name'] ?? '');
+        $type         = $data['template_type'] ?? 'custom';
+        $messageType  = $data['message_type'] ?? 'flex';
+        $altText      = $data['alt_text'] ?? null;
+        $contentTh    = $data['content_th'] ?? null;
+        $contentEn    = $data['content_en'] ?? null;
+        $variables    = $data['variables_json'] ?? null;
+        $isActive     = (int)($data['is_active'] ?? 1);
+
+        if ($id > 0) {
+            $stmt = $this->conn->prepare(
+                "UPDATE line_message_templates
+                 SET name=?, template_type=?, message_type=?, alt_text=?,
+                     content_th=?, content_en=?, variables_json=?, is_active=?
+                 WHERE id=? AND company_id=? AND deleted_at IS NULL"
+            );
+            $stmt->bind_param('sssssssiii',
+                $name, $type, $messageType, $altText,
+                $contentTh, $contentEn, $variables, $isActive,
+                $id, $companyId
+            );
+            $stmt->execute();
+            $stmt->close();
+            return $id;
+        }
+
+        $stmt = $this->conn->prepare(
+            "INSERT INTO line_message_templates
+             (company_id, name, template_type, message_type, alt_text,
+              content_th, content_en, variables_json, is_active, created_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        );
+        $stmt->bind_param('isssssssii',
+            $companyId, $name, $type, $messageType, $altText,
+            $contentTh, $contentEn, $variables, $isActive, $userId
+        );
+        $stmt->execute();
+        $newId = $stmt->insert_id;
+        $stmt->close();
+        return $newId;
+    }
+
+    public function deleteTemplate(int $id, int $companyId): bool
+    {
+        $stmt = $this->conn->prepare(
+            "UPDATE line_message_templates SET deleted_at = NOW() WHERE id = ? AND company_id = ?"
+        );
+        $stmt->bind_param('ii', $id, $companyId);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    /**
+     * Render a template by substituting {variable} tokens with the supplied vars.
+     * Returns ['alt_text' => ..., 'contents' => array (Flex JSON decoded) | 'text' => string]
+     */
+    public function renderTemplate(array $template, array $vars, bool $isThai): array
+    {
+        $body = $isThai
+            ? ($template['content_th'] ?? $template['content_en'] ?? '')
+            : ($template['content_en'] ?? $template['content_th'] ?? '');
+
+        // Token replace — keep it simple and safe
+        $rendered = $body;
+        foreach ($vars as $k => $v) {
+            $rendered = str_replace('{' . $k . '}', (string)$v, $rendered);
+        }
+
+        $altText = $template['alt_text'] ?? '';
+        foreach ($vars as $k => $v) {
+            $altText = str_replace('{' . $k . '}', (string)$v, $altText);
+        }
+
+        if (($template['message_type'] ?? 'flex') === 'text') {
+            return ['type' => 'text', 'text' => $rendered, 'alt_text' => $altText];
+        }
+
+        $decoded = json_decode($rendered, true);
+        return [
+            'type'     => 'flex',
+            'alt_text' => $altText,
+            'contents' => $decoded ?: [],
+        ];
+    }
+
+    // ====================================================================
+    // Tags
+    // ====================================================================
+
+    public function getTags(int $companyId): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT t.*, COUNT(m.id) AS user_count
+             FROM line_user_tags t
+             LEFT JOIN line_user_tag_map m ON m.tag_id = t.id
+             WHERE t.company_id = ? AND t.deleted_at IS NULL
+             GROUP BY t.id
+             ORDER BY t.name"
+        );
+        $stmt->bind_param('i', $companyId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    public function saveTag(int $companyId, string $name, string $color = '#3498db', ?string $description = null): int
+    {
+        $stmt = $this->conn->prepare(
+            "INSERT INTO line_user_tags (company_id, name, color, description) VALUES (?, ?, ?, ?)"
+        );
+        $stmt->bind_param('isss', $companyId, $name, $color, $description);
+        $stmt->execute();
+        $id = $stmt->insert_id;
+        $stmt->close();
+        return $id;
+    }
+
+    public function tagUser(int $companyId, int $lineUserId, int $tagId): bool
+    {
+        $stmt = $this->conn->prepare(
+            "INSERT IGNORE INTO line_user_tag_map (company_id, line_user_id, tag_id) VALUES (?, ?, ?)"
+        );
+        $stmt->bind_param('iii', $companyId, $lineUserId, $tagId);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    public function untagUser(int $companyId, int $lineUserId, int $tagId): bool
+    {
+        $stmt = $this->conn->prepare(
+            "DELETE FROM line_user_tag_map WHERE company_id = ? AND line_user_id = ? AND tag_id = ?"
+        );
+        $stmt->bind_param('iii', $companyId, $lineUserId, $tagId);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    // ====================================================================
+    // Audience resolution
+    // ====================================================================
+
+    /**
+     * Resolve an audience filter into a list of line_users.id rows.
+     * Used for both preview-count and actual recipient materialization.
+     *
+     * $audienceType in: all | tag | language | has_booked | last_active
+     * $filter examples:
+     *   ['tag_id' => 5]
+     *   ['language' => 'th']
+     *   ['days' => 30]   (last_active = interacted in last N days)
+     */
+    public function resolveAudience(int $companyId, string $audienceType, array $filter = [], int $limit = 100000): array
+    {
+        $base = "SELECT DISTINCT u.id, u.line_user_id
+                 FROM line_users u
+                 WHERE u.company_id = ?
+                   AND u.deleted_at IS NULL
+                   AND u.is_blocked = 0";
+
+        $sql    = $base;
+        $types  = 'i';
+        $params = [$companyId];
+
+        switch ($audienceType) {
+            case 'tag':
+                $tagId = (int)($filter['tag_id'] ?? 0);
+                $sql .= " AND EXISTS (
+                            SELECT 1 FROM line_user_tag_map m
+                            WHERE m.line_user_id = u.id AND m.tag_id = ?
+                          )";
+                $types .= 'i';
+                $params[] = $tagId;
+                break;
+
+            case 'language':
+                // We don't track language per user yet — proxy via last inbound message charset.
+                // For now, skip language filter and return all (TODO post-v6.3).
+                break;
+
+            case 'has_booked':
+                $sql .= " AND EXISTS (
+                            SELECT 1 FROM line_orders o
+                            WHERE o.line_user_id = u.id AND o.deleted_at IS NULL
+                              AND o.status IN ('confirmed','processing','completed')
+                          )";
+                break;
+
+            case 'last_active':
+                $days = max(1, (int)($filter['days'] ?? 30));
+                $sql .= " AND u.last_interaction_at >= DATE_SUB(NOW(), INTERVAL ? DAY)";
+                $types .= 'i';
+                $params[] = $days;
+                break;
+
+            case 'all':
+            default:
+                // no extra filter
+                break;
+        }
+
+        $sql .= " LIMIT ?";
+        $types .= 'i';
+        $params[] = $limit;
+
+        $stmt = $this->conn->prepare($sql);
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    public function audienceCount(int $companyId, string $audienceType, array $filter = []): int
+    {
+        return count($this->resolveAudience($companyId, $audienceType, $filter));
+    }
+
+    // ====================================================================
+    // Broadcasts
+    // ====================================================================
+
+    public function getBroadcasts(int $companyId, int $limit = 50): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT * FROM line_broadcasts
+             WHERE company_id = ? AND deleted_at IS NULL
+             ORDER BY COALESCE(scheduled_at, created_at) DESC
+             LIMIT ?"
+        );
+        $stmt->bind_param('ii', $companyId, $limit);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    public function getBroadcast(int $id, int $companyId): ?array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT * FROM line_broadcasts WHERE id = ? AND company_id = ? AND deleted_at IS NULL"
+        );
+        $stmt->bind_param('ii', $id, $companyId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ?: null;
+    }
+
+    public function saveBroadcast(int $companyId, array $data, ?int $userId = null): int
+    {
+        $id              = (int)($data['id'] ?? 0);
+        $name            = trim($data['name'] ?? '');
+        $audienceType    = $data['audience_type'] ?? 'all';
+        $audienceFilter  = $data['audience_filter_json'] ?? null;
+        $messageKind     = $data['message_kind'] ?? 'text';
+        $templateId      = !empty($data['template_id']) ? (int)$data['template_id'] : null;
+        $textTh          = $data['text_content_th'] ?? null;
+        $textEn          = $data['text_content_en'] ?? null;
+        $flexTh          = $data['flex_content_th'] ?? null;
+        $flexEn          = $data['flex_content_en'] ?? null;
+        $altText         = $data['alt_text'] ?? null;
+        $scheduledAt     = $data['scheduled_at'] ?? null;
+        $status          = $data['status'] ?? 'draft';
+
+        if ($id > 0) {
+            $stmt = $this->conn->prepare(
+                "UPDATE line_broadcasts
+                 SET name=?, status=?, audience_type=?, audience_filter_json=?,
+                     message_kind=?, template_id=?, text_content_th=?, text_content_en=?,
+                     flex_content_th=?, flex_content_en=?, alt_text=?, scheduled_at=?
+                 WHERE id=? AND company_id=? AND deleted_at IS NULL"
+            );
+            $stmt->bind_param('sssssissssssii',
+                $name, $status, $audienceType, $audienceFilter,
+                $messageKind, $templateId, $textTh, $textEn,
+                $flexTh, $flexEn, $altText, $scheduledAt,
+                $id, $companyId
+            );
+            $stmt->execute();
+            $stmt->close();
+            return $id;
+        }
+
+        $stmt = $this->conn->prepare(
+            "INSERT INTO line_broadcasts
+             (company_id, name, status, audience_type, audience_filter_json,
+              message_kind, template_id, text_content_th, text_content_en,
+              flex_content_th, flex_content_en, alt_text, scheduled_at, created_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        );
+        // 14 params: company_id(i), name(s), status(s), audience_type(s),
+        // audience_filter(s), message_kind(s), template_id(i),
+        // text_th(s), text_en(s), flex_th(s), flex_en(s), alt_text(s),
+        // scheduled_at(s), created_by(i)
+        $stmt->bind_param(
+            'issssisssssssi',
+            $companyId, $name, $status, $audienceType, $audienceFilter,
+            $messageKind, $templateId,
+            $textTh, $textEn, $flexTh, $flexEn,
+            $altText, $scheduledAt, $userId
+        );
+        $stmt->execute();
+        $newId = $stmt->insert_id;
+        $stmt->close();
+        return $newId;
+    }
+
+    /**
+     * Materialize recipients for a broadcast (one row per line_user) from the audience filter.
+     * Returns count of rows inserted.
+     */
+    public function materializeRecipients(int $broadcastId, int $companyId): int
+    {
+        $b = $this->getBroadcast($broadcastId, $companyId);
+        if (!$b) return 0;
+
+        $filter = json_decode($b['audience_filter_json'] ?? '[]', true) ?: [];
+        $audience = $this->resolveAudience($companyId, $b['audience_type'], $filter);
+
+        $count = 0;
+        $stmt = $this->conn->prepare(
+            "INSERT IGNORE INTO line_broadcast_recipients (company_id, broadcast_id, line_user_id) VALUES (?, ?, ?)"
+        );
+        foreach ($audience as $u) {
+            $uid = (int)$u['id'];
+            $stmt->bind_param('iii', $companyId, $broadcastId, $uid);
+            if ($stmt->execute()) $count++;
+        }
+        $stmt->close();
+
+        $this->conn->query(
+            "UPDATE line_broadcasts SET recipient_count = $count WHERE id = $broadcastId AND company_id = $companyId"
+        );
+
+        return $count;
+    }
+
+    /**
+     * Pull a chunk of pending recipients for a broadcast.
+     * Returns rows with line_user_id (LINE userId string) for the multicast call.
+     */
+    public function getPendingRecipientChunk(int $broadcastId, int $companyId, int $chunkSize = 500): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT r.id AS recipient_row_id, r.line_user_id AS db_user_id, u.line_user_id
+             FROM line_broadcast_recipients r
+             JOIN line_users u ON u.id = r.line_user_id
+             WHERE r.broadcast_id = ? AND r.company_id = ? AND r.status = 'pending'
+             LIMIT ?"
+        );
+        $stmt->bind_param('iii', $broadcastId, $companyId, $chunkSize);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    public function markRecipientsSent(array $recipientRowIds, int $companyId): void
+    {
+        if (empty($recipientRowIds)) return;
+        $ids = implode(',', array_map('intval', $recipientRowIds));
+        $companyId = (int)$companyId;
+        $this->conn->query(
+            "UPDATE line_broadcast_recipients
+             SET status='sent', sent_at=NOW()
+             WHERE id IN ($ids) AND company_id = $companyId"
+        );
+    }
+
+    public function markRecipientsFailed(array $recipientRowIds, int $companyId, string $error): void
+    {
+        if (empty($recipientRowIds)) return;
+        $ids = implode(',', array_map('intval', $recipientRowIds));
+        $companyId = (int)$companyId;
+        $stmt = $this->conn->prepare(
+            "UPDATE line_broadcast_recipients
+             SET status='failed', error_message=?
+             WHERE id IN ($ids) AND company_id = ?"
+        );
+        $stmt->bind_param('si', $error, $companyId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    public function updateBroadcastStatus(int $broadcastId, int $companyId, string $status, array $extra = []): bool
+    {
+        $sets = ['status = ?'];
+        $types = 's';
+        $params = [$status];
+
+        if (array_key_exists('sent_count', $extra)) {
+            $sets[] = 'sent_count = ?';
+            $types .= 'i';
+            $params[] = (int)$extra['sent_count'];
+        }
+        if (array_key_exists('failed_count', $extra)) {
+            $sets[] = 'failed_count = ?';
+            $types .= 'i';
+            $params[] = (int)$extra['failed_count'];
+        }
+        if (array_key_exists('last_error', $extra)) {
+            $sets[] = 'last_error = ?';
+            $types .= 's';
+            $params[] = $extra['last_error'];
+        }
+        if (!empty($extra['mark_started'])) {
+            $sets[] = 'sent_started_at = NOW()';
+        }
+        if (!empty($extra['mark_completed'])) {
+            $sets[] = 'sent_completed_at = NOW()';
+        }
+
+        $sql = "UPDATE line_broadcasts SET " . implode(', ', $sets) .
+               " WHERE id = ? AND company_id = ?";
+        $types .= 'ii';
+        $params[] = $broadcastId;
+        $params[] = $companyId;
+
+        $stmt = $this->conn->prepare($sql);
+        $stmt->bind_param($types, ...$params);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    /**
+     * Find broadcasts due to be sent (status=scheduled AND scheduled_at <= NOW()).
+     * Used by the cron worker. Cross-tenant — caller must respect.
+     */
+    public function findDueBroadcasts(int $limit = 20): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT * FROM line_broadcasts
+             WHERE status = 'scheduled'
+               AND scheduled_at IS NOT NULL
+               AND scheduled_at <= NOW()
+               AND deleted_at IS NULL
+             ORDER BY scheduled_at ASC
+             LIMIT ?"
+        );
+        $stmt->bind_param('i', $limit);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    /**
+     * Sum sent_count across this month's broadcasts for quota tracking.
+     */
+    public function getMonthlyBroadcastUsage(int $companyId): int
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT COALESCE(SUM(sent_count),0) AS used
+             FROM line_broadcasts
+             WHERE company_id = ?
+               AND deleted_at IS NULL
+               AND DATE_FORMAT(COALESCE(sent_completed_at, created_at), '%Y-%m') = DATE_FORMAT(NOW(), '%Y-%m')"
+        );
+        $stmt->bind_param('i', $companyId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return (int)($row['used'] ?? 0);
+    }
+}

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -30,6 +30,30 @@ class LineOA extends BaseModel
         return $result;
     }
 
+    /**
+     * Persist the latest LINE channel probe result + cached bot info.
+     * Called by LineOAController::probeConnection().
+     */
+    public function updateProbeResult(int $companyId, array $probe): bool
+    {
+        $name  = $probe['display_name'] ?? null;
+        $pic   = $probe['picture_url']  ?? null;
+        $basic = $probe['basic_id']     ?? null;
+        $stat  = $probe['status']       ?? 'unknown';
+        $err   = $probe['error']        ?? null;
+
+        $stmt = $this->conn->prepare(
+            "UPDATE line_oa_config
+             SET bot_display_name = ?, bot_picture_url = ?, bot_basic_id = ?,
+                 last_probe_at = NOW(), last_probe_status = ?, last_probe_error = ?
+             WHERE company_id = ? AND deleted_at IS NULL"
+        );
+        $stmt->bind_param('sssssi', $name, $pic, $basic, $stat, $err, $companyId);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
     public function saveConfig(int $companyId, array $data): bool
     {
         $existing = $this->getConfig($companyId);

--- a/app/Services/LineService.php
+++ b/app/Services/LineService.php
@@ -128,6 +128,69 @@ class LineService
         return $this->get("/profile/{$userId}");
     }
 
+    // ========== Bot / Channel Health ==========
+
+    /**
+     * Probe LINE channel: returns ['status' => connected|invalid_credentials|unreachable, ...]
+     * Wraps GET /v2/bot/info — the cheapest call that requires a valid token.
+     */
+    public function probeChannel(): array
+    {
+        $resp = $this->get('/info');
+        $code = $resp['http_code'] ?? 0;
+
+        if ($code === 200) {
+            return [
+                'status'       => 'connected',
+                'display_name' => $resp['displayName'] ?? null,
+                'picture_url'  => $resp['pictureUrl'] ?? null,
+                'basic_id'     => $resp['basicId'] ?? null,
+                'user_id'      => $resp['userId'] ?? null,
+            ];
+        }
+
+        if ($code === 401 || $code === 403) {
+            return [
+                'status' => 'invalid_credentials',
+                'error'  => $resp['message'] ?? 'Authentication failed',
+            ];
+        }
+
+        return [
+            'status' => 'unreachable',
+            'error'  => $resp['error'] ?? ($resp['message'] ?? "HTTP $code"),
+        ];
+    }
+
+    /**
+     * Get follower count from /v2/bot/insight/followers
+     * (LINE returns yesterday's number; today's is unavailable in real time.)
+     */
+    public function getFollowerCount(?string $date = null): ?int
+    {
+        $date = $date ?? date('Ymd', strtotime('-1 day'));
+        $resp = $this->get('/insight/followers?date=' . urlencode($date));
+        return isset($resp['followers']) ? (int)$resp['followers'] : null;
+    }
+
+    // ========== Multicast (broadcast to many users) ==========
+
+    /**
+     * Send the same messages to up to 500 users in one API call.
+     * Returns ['success' => bool, 'http_code' => int, ...].
+     * Caller is responsible for chunking >500 recipients across multiple calls.
+     */
+    public function multicast(array $userIds, array $messages): array
+    {
+        if (count($userIds) > 500) {
+            return ['success' => false, 'error' => 'multicast supports max 500 recipients per call', 'http_code' => 0];
+        }
+        return $this->post('/message/multicast', [
+            'to'       => array_values($userIds),
+            'messages' => $messages,
+        ]);
+    }
+
     // ========== Message Content ==========
 
     /**

--- a/app/Views/line-oa/_nav.php
+++ b/app/Views/line-oa/_nav.php
@@ -17,6 +17,8 @@ $_navItems = [
     'line_messages'     => ['icon' => 'fa-comments',        'en' => 'Messages',     'th' => 'ข้อความ'],
     'line_users'        => ['icon' => 'fa-users',           'en' => 'Users',        'th' => 'ผู้ใช้'],
     'line_auto_replies' => ['icon' => 'fa-reply-all',       'en' => 'Auto Replies', 'th' => 'ตอบกลับอัตโนมัติ'],
+    'line_templates'    => ['icon' => 'fa-clone',           'en' => 'Templates',    'th' => 'เทมเพลต'],
+    'line_broadcasts'   => ['icon' => 'fa-bullhorn',        'en' => 'Broadcasts',   'th' => 'ส่งกลุ่ม'],
     'line_send_message' => ['icon' => 'fa-paper-plane',     'en' => 'Send Message', 'th' => 'ส่งข้อความ'],
 ];
 $_navCurrentIcon = $navIcon ?? ($_navItems[$currentNavPage ?? '']['icon'] ?? 'fa-comment');

--- a/app/Views/line-oa/broadcast-compose.php
+++ b/app/Views/line-oa/broadcast-compose.php
@@ -1,0 +1,264 @@
+<?php
+$pageTitle = 'LINE OA — Compose Broadcast';
+$lang = (isset($_SESSION['lang']) && $_SESSION['lang'] == 1) ? 'th' : 'en';
+$isThai = ($lang === 'th');
+$isNew = empty($broadcast);
+$labels = [
+    'en' => [
+        'page_title' => $isNew ? 'New Broadcast' : 'Edit Broadcast',
+        'name' => 'Campaign Name',
+        'audience' => 'Audience',
+        'audience_all' => 'All friends',
+        'audience_tag' => 'By tag',
+        'audience_has_booked' => 'Has booked',
+        'audience_last_active' => 'Active in last N days',
+        'tag_select' => 'Select tag',
+        'days' => 'Days',
+        'recipient_count' => 'Recipients',
+        'message' => 'Message',
+        'message_text' => 'Plain text',
+        'message_template' => 'From template',
+        'message_custom_flex' => 'Custom Flex JSON',
+        'pick_template' => 'Pick a template',
+        'text_th' => 'Thai text', 'text_en' => 'English text',
+        'flex_th' => 'Thai Flex JSON', 'flex_en' => 'English Flex JSON',
+        'alt_text' => 'Notification text',
+        'schedule' => 'Schedule',
+        'send_now' => 'Send Now',
+        'save_draft' => 'Save Draft',
+        'schedule_btn' => 'Schedule',
+        'cancel' => 'Cancel',
+        'schedule_at' => 'Send at',
+        'confirm_send' => 'Send this broadcast immediately to {N} recipients?',
+    ],
+    'th' => [
+        'page_title' => $isNew ? 'แคมเปญใหม่' : 'แก้ไขแคมเปญ',
+        'name' => 'ชื่อแคมเปญ',
+        'audience' => 'กลุ่มเป้าหมาย',
+        'audience_all' => 'เพื่อนทั้งหมด',
+        'audience_tag' => 'ตามแท็ก',
+        'audience_has_booked' => 'เคยจอง',
+        'audience_last_active' => 'ใช้งานใน N วันล่าสุด',
+        'tag_select' => 'เลือกแท็ก',
+        'days' => 'จำนวนวัน',
+        'recipient_count' => 'จำนวนผู้รับ',
+        'message' => 'ข้อความ',
+        'message_text' => 'ข้อความธรรมดา',
+        'message_template' => 'จากเทมเพลต',
+        'message_custom_flex' => 'Flex JSON กำหนดเอง',
+        'pick_template' => 'เลือกเทมเพลต',
+        'text_th' => 'ข้อความภาษาไทย', 'text_en' => 'ข้อความภาษาอังกฤษ',
+        'flex_th' => 'Flex JSON ภาษาไทย', 'flex_en' => 'Flex JSON ภาษาอังกฤษ',
+        'alt_text' => 'ข้อความแจ้งเตือน',
+        'schedule' => 'ตั้งเวลา',
+        'send_now' => 'ส่งทันที',
+        'save_draft' => 'บันทึกแบบร่าง',
+        'schedule_btn' => 'ตั้งเวลาส่ง',
+        'cancel' => 'ยกเลิก',
+        'schedule_at' => 'ส่งเวลา',
+        'confirm_send' => 'ส่งแคมเปญนี้ไปยัง {N} รายทันที?',
+    ],
+];
+$t = $labels[$lang];
+
+$audienceFilter = !empty($broadcast['audience_filter_json'])
+    ? (json_decode($broadcast['audience_filter_json'], true) ?: [])
+    : [];
+$audienceType = $broadcast['audience_type'] ?? 'all';
+$messageKind  = $broadcast['message_kind'] ?? 'text';
+?>
+<?php $currentNavPage = 'line_broadcasts'; include __DIR__ . '/_nav.php'; ?>
+
+<?php if (!empty($_SESSION['flash_error'])): ?>
+<div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_error']); endif; ?>
+
+<form method="POST" action="index.php?page=line_broadcast_save" id="broadcast-form">
+    <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+    <input type="hidden" name="action" id="form-action" value="save_draft">
+    <input type="hidden" name="id" value="<?= (int)($broadcast['id'] ?? 0) ?>">
+
+    <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06); margin-bottom:16px;">
+        <h4 style="margin-top:0;"><i class="fa fa-bullhorn"></i> <?= $t['page_title'] ?></h4>
+
+        <div class="form-group">
+            <label><?= $t['name'] ?> *</label>
+            <input type="text" name="name" class="form-control" required maxlength="200"
+                   value="<?= htmlspecialchars($broadcast['name'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+    </div>
+
+    <div style="display:flex; gap:16px; flex-wrap:wrap;">
+
+    <!-- Step 1: Audience -->
+    <div style="flex:1; min-width:280px;">
+        <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+            <h5 style="margin-top:0;"><i class="fa fa-users"></i> 1. <?= $t['audience'] ?></h5>
+
+            <div class="form-group">
+                <label class="radio-inline"><input type="radio" name="audience_type" value="all" <?= $audienceType === 'all' ? 'checked' : '' ?>> <?= $t['audience_all'] ?></label><br>
+                <label class="radio-inline"><input type="radio" name="audience_type" value="tag" <?= $audienceType === 'tag' ? 'checked' : '' ?>> <?= $t['audience_tag'] ?></label><br>
+                <label class="radio-inline"><input type="radio" name="audience_type" value="has_booked" <?= $audienceType === 'has_booked' ? 'checked' : '' ?>> <?= $t['audience_has_booked'] ?></label><br>
+                <label class="radio-inline"><input type="radio" name="audience_type" value="last_active" <?= $audienceType === 'last_active' ? 'checked' : '' ?>> <?= $t['audience_last_active'] ?></label>
+            </div>
+
+            <div class="form-group" id="filter-tag" style="display:<?= $audienceType === 'tag' ? 'block' : 'none' ?>;">
+                <label><?= $t['tag_select'] ?></label>
+                <select name="audience_filter[tag_id]" class="form-control">
+                    <option value="">—</option>
+                    <?php foreach (($tags ?? []) as $tag): ?>
+                        <option value="<?= (int)$tag['id'] ?>" <?= ($audienceFilter['tag_id'] ?? 0) == $tag['id'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($tag['name'], ENT_QUOTES, 'UTF-8') ?> (<?= (int)($tag['user_count'] ?? 0) ?>)
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="form-group" id="filter-days" style="display:<?= $audienceType === 'last_active' ? 'block' : 'none' ?>;">
+                <label><?= $t['days'] ?></label>
+                <input type="number" name="audience_filter[days]" class="form-control" min="1" max="365"
+                       value="<?= (int)($audienceFilter['days'] ?? 30) ?>">
+            </div>
+
+            <div style="background:#f0f8ff; padding:12px; border-radius:8px; margin-top:16px;">
+                <strong><?= $t['recipient_count'] ?>:</strong>
+                <span id="audience-count" style="font-size:1.4rem; color:#06C755; font-weight:bold;">…</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Step 2: Message -->
+    <div style="flex:2; min-width:380px;">
+        <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+            <h5 style="margin-top:0;"><i class="fa fa-envelope"></i> 2. <?= $t['message'] ?></h5>
+
+            <div class="form-group">
+                <label class="radio-inline"><input type="radio" name="message_kind" value="text" <?= $messageKind === 'text' ? 'checked' : '' ?>> <?= $t['message_text'] ?></label>
+                <label class="radio-inline" style="margin-left:15px;"><input type="radio" name="message_kind" value="template" <?= $messageKind === 'template' ? 'checked' : '' ?>> <?= $t['message_template'] ?></label>
+                <label class="radio-inline" style="margin-left:15px;"><input type="radio" name="message_kind" value="custom_flex" <?= $messageKind === 'custom_flex' ? 'checked' : '' ?>> <?= $t['message_custom_flex'] ?></label>
+            </div>
+
+            <!-- Text mode -->
+            <div id="kind-text" style="display:<?= $messageKind === 'text' ? 'block' : 'none' ?>;">
+                <div class="form-group">
+                    <label>🇹🇭 <?= $t['text_th'] ?></label>
+                    <textarea name="text_content_th" class="form-control" rows="4"><?= htmlspecialchars($broadcast['text_content_th'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                </div>
+                <div class="form-group">
+                    <label>🇬🇧 <?= $t['text_en'] ?></label>
+                    <textarea name="text_content_en" class="form-control" rows="4"><?= htmlspecialchars($broadcast['text_content_en'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                </div>
+            </div>
+
+            <!-- Template mode -->
+            <div id="kind-template" style="display:<?= $messageKind === 'template' ? 'block' : 'none' ?>;">
+                <div class="form-group">
+                    <label><?= $t['pick_template'] ?></label>
+                    <select name="template_id" class="form-control">
+                        <option value="">—</option>
+                        <?php foreach (($templates ?? []) as $tpl): ?>
+                            <option value="<?= (int)$tpl['id'] ?>" <?= ($broadcast['template_id'] ?? 0) == $tpl['id'] ? 'selected' : '' ?>>
+                                <?= htmlspecialchars($tpl['name'], ENT_QUOTES, 'UTF-8') ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Custom Flex mode -->
+            <div id="kind-flex" style="display:<?= $messageKind === 'custom_flex' ? 'block' : 'none' ?>;">
+                <div class="form-group">
+                    <label>🇹🇭 <?= $t['flex_th'] ?></label>
+                    <textarea name="flex_content_th" class="form-control" rows="6" style="font-family:monospace; font-size:0.85rem;"><?= htmlspecialchars($broadcast['flex_content_th'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                </div>
+                <div class="form-group">
+                    <label>🇬🇧 <?= $t['flex_en'] ?></label>
+                    <textarea name="flex_content_en" class="form-control" rows="6" style="font-family:monospace; font-size:0.85rem;"><?= htmlspecialchars($broadcast['flex_content_en'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label><?= $t['alt_text'] ?></label>
+                <input type="text" name="alt_text" class="form-control" maxlength="400"
+                       value="<?= htmlspecialchars($broadcast['alt_text'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+        </div>
+    </div>
+
+    </div>
+
+    <!-- Step 3: Schedule + Send -->
+    <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06); margin-top:16px;">
+        <h5 style="margin-top:0;"><i class="fa fa-clock-o"></i> 3. <?= $t['schedule'] ?></h5>
+        <div class="form-group">
+            <label><?= $t['schedule_at'] ?></label>
+            <input type="datetime-local" name="scheduled_at" class="form-control" style="max-width:300px;"
+                   value="<?= !empty($broadcast['scheduled_at']) ? date('Y-m-d\TH:i', strtotime($broadcast['scheduled_at'])) : '' ?>">
+        </div>
+
+        <div style="margin-top:20px;">
+            <button type="button" class="btn btn-default" onclick="submitWith('save_draft')"><i class="fa fa-save"></i> <?= $t['save_draft'] ?></button>
+            <button type="button" class="btn btn-info" onclick="submitWith('schedule')"><i class="fa fa-clock-o"></i> <?= $t['schedule_btn'] ?></button>
+            <button type="button" class="btn btn-success" onclick="confirmSendNow()"><i class="fa fa-paper-plane"></i> <?= $t['send_now'] ?></button>
+            <a href="index.php?page=line_broadcasts" class="btn btn-link"><?= $t['cancel'] ?></a>
+        </div>
+    </div>
+</form>
+
+<script>
+(function() {
+    function show(id, on) { document.getElementById(id).style.display = on ? 'block' : 'none'; }
+
+    // Audience-type radios -> show/hide sub-filters + refresh count
+    document.querySelectorAll('input[name="audience_type"]').forEach(function(r) {
+        r.addEventListener('change', function() {
+            show('filter-tag',  r.value === 'tag'  && r.checked);
+            show('filter-days', r.value === 'last_active' && r.checked);
+            refreshAudienceCount();
+        });
+    });
+    document.querySelectorAll('select[name="audience_filter[tag_id]"], input[name="audience_filter[days]"]').forEach(function(el) {
+        el.addEventListener('change', refreshAudienceCount);
+    });
+
+    // Message-kind radios -> swap sections
+    document.querySelectorAll('input[name="message_kind"]').forEach(function(r) {
+        r.addEventListener('change', function() {
+            show('kind-text',     r.value === 'text'        && r.checked);
+            show('kind-template', r.value === 'template'    && r.checked);
+            show('kind-flex',     r.value === 'custom_flex' && r.checked);
+        });
+    });
+
+    var lastCount = 0;
+    function refreshAudienceCount() {
+        var type   = document.querySelector('input[name="audience_type"]:checked').value;
+        var filter = {};
+        var tagSel = document.querySelector('select[name="audience_filter[tag_id]"]');
+        if (tagSel && tagSel.value) filter.tag_id = parseInt(tagSel.value, 10);
+        var daysIn = document.querySelector('input[name="audience_filter[days]"]');
+        if (daysIn && daysIn.value) filter.days = parseInt(daysIn.value, 10);
+        var url = 'index.php?page=line_broadcast_audience_count&audience_type=' + encodeURIComponent(type) +
+                  '&filter=' + encodeURIComponent(JSON.stringify(filter));
+        fetch(url, { credentials: 'same-origin' })
+            .then(function(r) { return r.json(); })
+            .then(function(j) {
+                lastCount = j.count || 0;
+                document.getElementById('audience-count').textContent = lastCount.toLocaleString();
+            })
+            .catch(function() { document.getElementById('audience-count').textContent = '?'; });
+    }
+
+    window.submitWith = function(action) {
+        document.getElementById('form-action').value = action;
+        document.getElementById('broadcast-form').submit();
+    };
+    window.confirmSendNow = function() {
+        var msg = <?= json_encode($t['confirm_send']) ?>.replace('{N}', lastCount.toLocaleString());
+        if (confirm(msg)) submitWith('send_now');
+    };
+
+    refreshAudienceCount();
+})();
+</script>
+</div>

--- a/app/Views/line-oa/broadcast-view.php
+++ b/app/Views/line-oa/broadcast-view.php
@@ -1,0 +1,51 @@
+<?php
+$pageTitle = 'LINE OA — Broadcast';
+$lang = (isset($_SESSION['lang']) && $_SESSION['lang'] == 1) ? 'th' : 'en';
+$isThai = ($lang === 'th');
+$t = [
+    'page_title'    => $isThai ? 'ดูแคมเปญ' : 'Broadcast Detail',
+    'back'          => $isThai ? 'กลับไปยังรายการ' : 'Back to list',
+    'name'          => $isThai ? 'ชื่อ' : 'Name',
+    'status'        => $isThai ? 'สถานะ' : 'Status',
+    'audience'      => $isThai ? 'กลุ่มเป้าหมาย' : 'Audience',
+    'recipients'    => $isThai ? 'จำนวนผู้รับ' : 'Recipients',
+    'sent'          => $isThai ? 'ส่งสำเร็จ' : 'Sent',
+    'failed'        => $isThai ? 'ล้มเหลว' : 'Failed',
+    'started'       => $isThai ? 'เริ่มส่ง' : 'Started',
+    'completed'     => $isThai ? 'เสร็จสิ้น' : 'Completed',
+    'last_error'    => $isThai ? 'ข้อผิดพลาดล่าสุด' : 'Last error',
+];
+?>
+<?php $currentNavPage = 'line_broadcasts'; include __DIR__ . '/_nav.php'; ?>
+
+<a href="index.php?page=line_broadcasts" class="btn btn-default btn-sm" style="margin-bottom:16px;">
+    <i class="fa fa-arrow-left"></i> <?= $t['back'] ?>
+</a>
+
+<div style="background:white; border-radius:12px; padding:24px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+    <h4 style="margin-top:0;"><i class="fa fa-bullhorn"></i> <?= htmlspecialchars($broadcast['name'], ENT_QUOTES, 'UTF-8') ?></h4>
+
+    <table class="table table-condensed">
+        <tr><th style="width:180px;"><?= $t['status'] ?></th>
+            <td><span class="label label-info"><?= htmlspecialchars($broadcast['status'], ENT_QUOTES, 'UTF-8') ?></span></td></tr>
+        <tr><th><?= $t['audience'] ?></th>
+            <td><?= htmlspecialchars($broadcast['audience_type'], ENT_QUOTES, 'UTF-8') ?></td></tr>
+        <tr><th><?= $t['recipients'] ?></th>
+            <td><?= number_format((int)($broadcast['recipient_count'] ?? 0)) ?></td></tr>
+        <tr><th><?= $t['sent'] ?></th>
+            <td style="color:#06C755;"><strong><?= number_format((int)($broadcast['sent_count'] ?? 0)) ?></strong></td></tr>
+        <tr><th><?= $t['failed'] ?></th>
+            <td style="color:<?= ($broadcast['failed_count'] ?? 0) > 0 ? '#e74c3c' : '#999' ?>;">
+                <?= number_format((int)($broadcast['failed_count'] ?? 0)) ?>
+            </td></tr>
+        <tr><th><?= $t['started'] ?></th>
+            <td><?= !empty($broadcast['sent_started_at']) ? date('Y-m-d H:i:s', strtotime($broadcast['sent_started_at'])) : '-' ?></td></tr>
+        <tr><th><?= $t['completed'] ?></th>
+            <td><?= !empty($broadcast['sent_completed_at']) ? date('Y-m-d H:i:s', strtotime($broadcast['sent_completed_at'])) : '-' ?></td></tr>
+        <?php if (!empty($broadcast['last_error'])): ?>
+        <tr><th><?= $t['last_error'] ?></th>
+            <td><code><?= htmlspecialchars($broadcast['last_error'], ENT_QUOTES, 'UTF-8') ?></code></td></tr>
+        <?php endif; ?>
+    </table>
+</div>
+</div>

--- a/app/Views/line-oa/broadcasts-index.php
+++ b/app/Views/line-oa/broadcasts-index.php
@@ -1,0 +1,144 @@
+<?php
+$pageTitle = 'LINE OA — Broadcasts';
+$lang = (isset($_SESSION['lang']) && $_SESSION['lang'] == 1) ? 'th' : 'en';
+$isThai = ($lang === 'th');
+$labels = [
+    'en' => [
+        'page_title' => 'Broadcast Campaigns',
+        'new'        => 'New Broadcast',
+        'name'       => 'Name',
+        'status'     => 'Status',
+        'audience'   => 'Audience',
+        'recipients' => 'Recipients',
+        'sent'       => 'Sent',
+        'failed'     => 'Failed',
+        'when'       => 'When',
+        'actions'    => 'Actions',
+        'no_broadcasts' => 'No broadcasts yet. Create your first campaign to reach LINE friends.',
+        'view'       => 'View',
+        'edit'       => 'Edit',
+        'monthly_quota' => 'Monthly quota',
+        'quota_used' => 'used',
+        'audience_types' => [
+            'all' => 'All friends', 'tag' => 'By tag', 'language' => 'By language',
+            'has_booked' => 'Has booked', 'last_active' => 'Recently active',
+        ],
+        'status_labels' => [
+            'draft' => 'Draft', 'scheduled' => 'Scheduled', 'sending' => 'Sending',
+            'sent' => 'Sent', 'partial' => 'Partial', 'failed' => 'Failed', 'cancelled' => 'Cancelled',
+        ],
+    ],
+    'th' => [
+        'page_title' => 'แคมเปญส่งกลุ่ม',
+        'new'        => 'สร้างแคมเปญ',
+        'name'       => 'ชื่อ',
+        'status'     => 'สถานะ',
+        'audience'   => 'กลุ่มเป้าหมาย',
+        'recipients' => 'จำนวนผู้รับ',
+        'sent'       => 'ส่งแล้ว',
+        'failed'     => 'ล้มเหลว',
+        'when'       => 'เวลา',
+        'actions'    => 'จัดการ',
+        'no_broadcasts' => 'ยังไม่มีแคมเปญ สร้างแคมเปญแรกเพื่อส่งถึงเพื่อน LINE',
+        'view'       => 'ดู',
+        'edit'       => 'แก้ไข',
+        'monthly_quota' => 'โควต้ารายเดือน',
+        'quota_used' => 'ใช้ไป',
+        'audience_types' => [
+            'all' => 'เพื่อนทั้งหมด', 'tag' => 'ตามแท็ก', 'language' => 'ตามภาษา',
+            'has_booked' => 'เคยจอง', 'last_active' => 'ใช้งานล่าสุด',
+        ],
+        'status_labels' => [
+            'draft' => 'แบบร่าง', 'scheduled' => 'ตั้งเวลา', 'sending' => 'กำลังส่ง',
+            'sent' => 'ส่งแล้ว', 'partial' => 'ส่งบางส่วน', 'failed' => 'ล้มเหลว', 'cancelled' => 'ยกเลิก',
+        ],
+    ],
+];
+$t = $labels[$lang];
+
+$statusBadge = [
+    'draft' => 'default', 'scheduled' => 'info', 'sending' => 'primary',
+    'sent' => 'success', 'partial' => 'warning', 'failed' => 'danger', 'cancelled' => 'default',
+];
+$quotaPct = $quota_limit > 0 ? min(100, round(($quota_used / $quota_limit) * 100)) : 0;
+$quotaColor = $quotaPct < 70 ? '#06C755' : ($quotaPct < 95 ? '#f39c12' : '#e74c3c');
+?>
+<?php $currentNavPage = 'line_broadcasts'; include __DIR__ . '/_nav.php'; ?>
+
+<?php if (!empty($_SESSION['flash_success'])): ?>
+<div class="alert alert-success alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_success'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_success']); endif; ?>
+<?php if (!empty($_SESSION['flash_error'])): ?>
+<div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_error']); endif; ?>
+
+<!-- Quota meter -->
+<div style="background:white; border-radius:12px; padding:16px 20px; margin-bottom:16px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
+        <strong><?= $t['monthly_quota'] ?></strong>
+        <small><?= number_format($quota_used) ?> / <?= number_format($quota_limit) ?> <?= $t['quota_used'] ?> (<?= $quotaPct ?>%)</small>
+    </div>
+    <div style="height:8px; background:#eee; border-radius:4px; overflow:hidden;">
+        <div style="height:100%; width:<?= $quotaPct ?>%; background:<?= $quotaColor ?>;"></div>
+    </div>
+</div>
+
+<div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:15px; flex-wrap:wrap; gap:10px;">
+        <h4 style="margin:0;"><i class="fa fa-bullhorn"></i> <?= $t['page_title'] ?></h4>
+        <a href="index.php?page=line_broadcast_compose" class="btn btn-success btn-sm">
+            <i class="fa fa-plus"></i> <?= $t['new'] ?>
+        </a>
+    </div>
+
+    <?php if (empty($broadcasts)): ?>
+        <p style="text-align:center; padding:40px 20px; color:#999;"><?= $t['no_broadcasts'] ?></p>
+    <?php else: ?>
+    <div class="table-responsive">
+        <table class="table table-hover" style="margin:0;">
+            <thead>
+                <tr>
+                    <th><?= $t['name'] ?></th>
+                    <th><?= $t['status'] ?></th>
+                    <th><?= $t['audience'] ?></th>
+                    <th style="text-align:right;"><?= $t['recipients'] ?></th>
+                    <th style="text-align:right;"><?= $t['sent'] ?></th>
+                    <th style="text-align:right;"><?= $t['failed'] ?></th>
+                    <th><?= $t['when'] ?></th>
+                    <th style="text-align:right;"><?= $t['actions'] ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($broadcasts as $b): ?>
+                <tr>
+                    <td><strong><?= htmlspecialchars($b['name'], ENT_QUOTES, 'UTF-8') ?></strong></td>
+                    <td>
+                        <span class="label label-<?= $statusBadge[$b['status']] ?? 'default' ?>">
+                            <?= $t['status_labels'][$b['status']] ?? $b['status'] ?>
+                        </span>
+                    </td>
+                    <td><?= $t['audience_types'][$b['audience_type']] ?? $b['audience_type'] ?></td>
+                    <td style="text-align:right;"><?= number_format($b['recipient_count'] ?? 0) ?></td>
+                    <td style="text-align:right; color:#06C755;"><?= number_format($b['sent_count'] ?? 0) ?></td>
+                    <td style="text-align:right; color:<?= ($b['failed_count'] ?? 0) > 0 ? '#e74c3c' : '#999' ?>;"><?= number_format($b['failed_count'] ?? 0) ?></td>
+                    <td>
+                        <?php
+                        $when = $b['sent_completed_at'] ?? ($b['scheduled_at'] ?? $b['created_at']);
+                        echo $when ? date('M d, H:i', strtotime($when)) : '-';
+                        ?>
+                    </td>
+                    <td style="text-align:right;">
+                        <?php $isReadonly = in_array($b['status'], ['sent','sending','partial']); ?>
+                        <a href="index.php?page=line_broadcast_compose&amp;id=<?= (int)$b['id'] ?>" class="btn btn-xs btn-outline-primary">
+                            <i class="fa fa-<?= $isReadonly ? 'eye' : 'pencil' ?>"></i>
+                            <?= $isReadonly ? $t['view'] : $t['edit'] ?>
+                        </a>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <?php endif; ?>
+</div>
+</div>

--- a/app/Views/line-oa/dashboard.php
+++ b/app/Views/line-oa/dashboard.php
@@ -198,13 +198,53 @@ $statusBadge = [
                 <tr>
                     <th style="width:140px; border-top:none;"><?= $t['connection_status'] ?></th>
                     <td style="border-top:none;">
-                        <?php if ($config['is_active']): ?>
+                        <span id="line-health-badge">
+                        <?php
+                        // v6.3 — show real probe state (not just is_active toggle)
+                        $probeStatus = $config['last_probe_status'] ?? 'unknown';
+                        $probeAt     = $config['last_probe_at'] ?? null;
+                        if ($probeStatus === 'connected'): ?>
                             <span class="label label-success"><i class="fa fa-plug"></i> <?= $t['connected'] ?></span>
+                        <?php elseif ($probeStatus === 'invalid_credentials'): ?>
+                            <span class="label label-warning"><i class="fa fa-key"></i> <?= ($lang === 'th') ? 'ข้อมูลรับรองไม่ถูกต้อง' : 'Invalid credentials' ?></span>
+                        <?php elseif ($probeStatus === 'unreachable'): ?>
+                            <span class="label label-danger"><i class="fa fa-chain-broken"></i> <?= ($lang === 'th') ? 'ติดต่อเซิร์ฟเวอร์ LINE ไม่ได้' : 'Unreachable' ?></span>
+                        <?php elseif ($config['is_active']): ?>
+                            <span class="label label-info"><i class="fa fa-question-circle"></i> <?= ($lang === 'th') ? 'ยังไม่ตรวจสอบ' : 'Not yet probed' ?></span>
                         <?php else: ?>
-                            <span class="label label-danger"><i class="fa fa-times-circle"></i> <?= $t['disconnected'] ?></span>
+                            <span class="label label-default"><i class="fa fa-times-circle"></i> <?= $t['disconnected'] ?></span>
+                        <?php endif; ?>
+                        </span>
+                        <button type="button" id="line-health-retest" class="btn btn-xs btn-outline-secondary" style="margin-left:8px;" title="<?= ($lang === 'th') ? 'ทดสอบอีกครั้ง' : 'Re-test' ?>">
+                            <i class="fa fa-refresh"></i>
+                        </button>
+                        <?php if ($probeAt): ?>
+                            <small class="text-muted" style="display:block; margin-top:4px;">
+                                <?= ($lang === 'th') ? 'ตรวจสอบล่าสุด' : 'Last checked' ?>:
+                                <?= date('M d, H:i', strtotime($probeAt)) ?>
+                            </small>
+                        <?php endif; ?>
+                        <?php if (!empty($config['last_probe_error'])): ?>
+                            <small class="text-danger" style="display:block; margin-top:4px;">
+                                <?= htmlspecialchars($config['last_probe_error'], ENT_QUOTES, 'UTF-8') ?>
+                            </small>
                         <?php endif; ?>
                     </td>
                 </tr>
+                <?php if (!empty($config['bot_display_name'])): ?>
+                <tr>
+                    <th><?= ($lang === 'th') ? 'ชื่อบอท' : 'Bot Name' ?></th>
+                    <td>
+                        <?php if (!empty($config['bot_picture_url'])): ?>
+                            <img src="<?= htmlspecialchars($config['bot_picture_url'], ENT_QUOTES, 'UTF-8') ?>" alt="" style="width:24px; height:24px; border-radius:50%; vertical-align:middle; margin-right:6px;">
+                        <?php endif; ?>
+                        <?= htmlspecialchars($config['bot_display_name'], ENT_QUOTES, 'UTF-8') ?>
+                        <?php if (!empty($config['bot_basic_id'])): ?>
+                            <small class="text-muted">(<?= htmlspecialchars($config['bot_basic_id'], ENT_QUOTES, 'UTF-8') ?>)</small>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+                <?php endif; ?>
                 <tr>
                     <th><?= $t['auto_reply'] ?></th>
                     <td>
@@ -395,3 +435,37 @@ $statusBadge = [
 <?php endif; ?>
 
 </div>
+
+<?php if (!empty($config)): ?>
+<script>
+// v6.3 — Health probe re-test button
+(function() {
+    var btn = document.getElementById('line-health-retest');
+    var badge = document.getElementById('line-health-badge');
+    if (!btn || !badge) return;
+    btn.addEventListener('click', function() {
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
+        fetch('index.php?page=line_probe', { credentials: 'same-origin' })
+            .then(function(r) { return r.json(); })
+            .then(function(j) {
+                var map = {
+                    connected:           '<span class="label label-success"><i class="fa fa-plug"></i> Connected</span>',
+                    invalid_credentials: '<span class="label label-warning"><i class="fa fa-key"></i> Invalid credentials</span>',
+                    unreachable:         '<span class="label label-danger"><i class="fa fa-chain-broken"></i> Unreachable</span>',
+                    unknown:             '<span class="label label-default"><i class="fa fa-question-circle"></i> Unknown</span>'
+                };
+                badge.innerHTML = map[j.status] || map.unknown;
+                if (j.status === 'connected') {
+                    setTimeout(function() { window.location.reload(); }, 800);
+                }
+            })
+            .catch(function() { badge.innerHTML = '<span class="label label-danger">Probe failed</span>'; })
+            .finally(function() {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="fa fa-refresh"></i>';
+            });
+    });
+})();
+</script>
+<?php endif; ?>

--- a/app/Views/line-oa/template-edit.php
+++ b/app/Views/line-oa/template-edit.php
@@ -1,0 +1,180 @@
+<?php
+$pageTitle = 'LINE OA — Edit Template';
+$lang = (isset($_SESSION['lang']) && $_SESSION['lang'] == 1) ? 'th' : 'en';
+$isThai = ($lang === 'th');
+$isNew = empty($template);
+$labels = [
+    'en' => [
+        'page_title' => $isNew ? 'New Template' : 'Edit Template',
+        'name'         => 'Name',
+        'template_type' => 'Type',
+        'message_type' => 'Message Format',
+        'alt_text'     => 'Notification Text',
+        'alt_help'     => 'Shown in the LINE notification preview before the user opens the chat.',
+        'content_th'   => 'Thai Content (JSON or text)',
+        'content_en'   => 'English Content (JSON or text)',
+        'variables'    => 'Variables (one per line, e.g. tour_name)',
+        'active'       => 'Active',
+        'save'         => 'Save Template',
+        'cancel'       => 'Cancel',
+        'help'         => 'Use {variable_name} placeholders. They will be replaced at send time.',
+        'flex_help'    => 'For Flex messages, paste the LINE Flex bubble JSON. Use the official designer at developers.line.biz/flex-simulator.',
+        'yes' => 'Yes', 'no' => 'No',
+    ],
+    'th' => [
+        'page_title' => $isNew ? 'เทมเพลตใหม่' : 'แก้ไขเทมเพลต',
+        'name'         => 'ชื่อ',
+        'template_type' => 'ประเภท',
+        'message_type' => 'รูปแบบข้อความ',
+        'alt_text'     => 'ข้อความแจ้งเตือน',
+        'alt_help'     => 'แสดงในการแจ้งเตือน LINE ก่อนผู้ใช้เปิดแชท',
+        'content_th'   => 'เนื้อหาภาษาไทย (JSON หรือข้อความ)',
+        'content_en'   => 'เนื้อหาภาษาอังกฤษ (JSON หรือข้อความ)',
+        'variables'    => 'ตัวแปร (บรรทัดละ 1 ชื่อ เช่น tour_name)',
+        'active'       => 'ใช้งาน',
+        'save'         => 'บันทึก',
+        'cancel'       => 'ยกเลิก',
+        'help'         => 'ใช้ {ชื่อตัวแปร} เป็นตัวแทน จะถูกแทนที่ตอนส่ง',
+        'flex_help'    => 'สำหรับข้อความ Flex ให้วาง JSON Bubble ของ LINE ใช้เครื่องมือออกแบบที่ developers.line.biz/flex-simulator',
+        'yes' => 'ใช่', 'no' => 'ไม่ใช่',
+    ],
+];
+$t = $labels[$lang];
+$typeOptions = [
+    'tour_package'     => $isThai ? 'แพ็คเกจทัวร์'  : 'Tour Package',
+    'quotation'        => $isThai ? 'ใบเสนอราคา'   : 'Quotation',
+    'booking_confirm'  => $isThai ? 'ยืนยันการจอง' : 'Booking Confirm',
+    'payment_reminder' => $isThai ? 'แจ้งชำระเงิน' : 'Payment Reminder',
+    'voucher'          => $isThai ? 'วอเชอร์'      : 'Voucher',
+    'custom'           => $isThai ? 'อื่นๆ'         : 'Custom',
+];
+
+// Decode variables_json into newline-separated text for the textarea
+$variablesText = '';
+if (!empty($template['variables_json'])) {
+    $vars = json_decode($template['variables_json'], true);
+    if (is_array($vars)) $variablesText = implode("\n", $vars);
+}
+?>
+<?php $currentNavPage = 'line_templates'; include __DIR__ . '/_nav.php'; ?>
+
+<?php if (!empty($_SESSION['flash_error'])): ?>
+<div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_error']); endif; ?>
+
+<form method="POST" action="index.php?page=line_template_save" id="template-form">
+    <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+    <input type="hidden" name="action" value="save">
+    <input type="hidden" name="id" value="<?= (int)($template['id'] ?? 0) ?>">
+
+    <div style="display:flex; gap:20px; flex-wrap:wrap;">
+
+    <div style="flex:2; min-width:380px;">
+        <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+            <h4 style="margin-top:0;"><i class="fa fa-clone"></i> <?= $t['page_title'] ?></h4>
+
+            <div class="form-group">
+                <label><?= $t['name'] ?> *</label>
+                <input type="text" name="name" class="form-control" required maxlength="150"
+                       value="<?= htmlspecialchars($template['name'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+
+            <div class="form-group">
+                <label><?= $t['template_type'] ?></label>
+                <select name="template_type" class="form-control">
+                    <?php foreach ($typeOptions as $val => $label): ?>
+                    <option value="<?= $val ?>" <?= ($template['template_type'] ?? 'custom') === $val ? 'selected' : '' ?>><?= $label ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label><?= $t['message_type'] ?></label>
+                <select name="message_type" class="form-control" id="message-type-select">
+                    <option value="flex" <?= ($template['message_type'] ?? 'flex') === 'flex' ? 'selected' : '' ?>>Flex (rich card)</option>
+                    <option value="text" <?= ($template['message_type'] ?? '') === 'text' ? 'selected' : '' ?>>Text</option>
+                </select>
+                <p class="help-block" id="flex-help-text" style="display:<?= ($template['message_type'] ?? 'flex') === 'flex' ? 'block' : 'none' ?>;">
+                    <?= $t['flex_help'] ?>
+                </p>
+            </div>
+
+            <div class="form-group">
+                <label><?= $t['alt_text'] ?></label>
+                <input type="text" name="alt_text" class="form-control" maxlength="400"
+                       value="<?= htmlspecialchars($template['alt_text'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                <p class="help-block"><?= $t['alt_help'] ?></p>
+            </div>
+
+            <div class="form-group">
+                <label>🇹🇭 <?= $t['content_th'] ?></label>
+                <textarea name="content_th" class="form-control" rows="10" style="font-family:monospace; font-size:0.85rem;"><?= htmlspecialchars($template['content_th'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+            </div>
+
+            <div class="form-group">
+                <label>🇬🇧 <?= $t['content_en'] ?></label>
+                <textarea name="content_en" class="form-control" rows="10" style="font-family:monospace; font-size:0.85rem;"><?= htmlspecialchars($template['content_en'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+            </div>
+
+            <div class="form-group">
+                <label><?= $t['variables'] ?></label>
+                <textarea id="variables-text" class="form-control" rows="4" placeholder="tour_name&#10;price&#10;date"><?= htmlspecialchars($variablesText, ENT_QUOTES, 'UTF-8') ?></textarea>
+                <input type="hidden" name="variables_json" id="variables-json" value="<?= htmlspecialchars($template['variables_json'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                <p class="help-block"><?= $t['help'] ?></p>
+            </div>
+
+            <div class="form-group">
+                <label><?= $t['active'] ?></label>
+                <select name="is_active" class="form-control">
+                    <option value="1" <?= ($template['is_active'] ?? 1) ? 'selected' : '' ?>><?= $t['yes'] ?></option>
+                    <option value="0" <?= !($template['is_active'] ?? 1) ? 'selected' : '' ?>><?= $t['no'] ?></option>
+                </select>
+            </div>
+
+            <button type="submit" class="btn btn-primary"><i class="fa fa-save"></i> <?= $t['save'] ?></button>
+            <a href="index.php?page=line_templates" class="btn btn-default"><?= $t['cancel'] ?></a>
+        </div>
+    </div>
+
+    <div style="flex:1; min-width:280px;">
+        <div style="background:#f9f9f9; border-radius:12px; padding:20px;">
+            <h5><i class="fa fa-lightbulb-o"></i> <?= $isThai ? 'ตัวอย่าง JSON Flex' : 'Flex JSON example' ?></h5>
+            <pre style="font-size:0.7rem; background:white; padding:10px; border-radius:6px; max-height:280px; overflow:auto;">{
+  "type":"bubble",
+  "hero":{
+    "type":"image",
+    "url":"{image_url}",
+    "size":"full"
+  },
+  "body":{
+    "type":"box",
+    "layout":"vertical",
+    "contents":[
+      {"type":"text","text":"{tour_name}","weight":"bold","size":"xl"},
+      {"type":"text","text":"฿{price}","color":"#06C755"}
+    ]
+  }
+}</pre>
+            <p style="font-size:0.85rem; margin-top:10px;">
+                <?= $isThai ? 'ตัวอักษร' : 'Tokens' ?>:
+                <code>{tour_name}</code>, <code>{price}</code>, <code>{image_url}</code>, <code>{book_url}</code>
+            </p>
+        </div>
+    </div>
+
+    </div>
+</form>
+
+<script>
+// Sync the human-friendly variables textarea -> hidden JSON field on submit
+document.getElementById('template-form').addEventListener('submit', function() {
+    var raw = document.getElementById('variables-text').value || '';
+    var lines = raw.split(/\r?\n/).map(function(s) { return s.trim(); }).filter(Boolean);
+    document.getElementById('variables-json').value = JSON.stringify(lines);
+});
+// Toggle the flex-help hint based on message_type
+document.getElementById('message-type-select').addEventListener('change', function() {
+    document.getElementById('flex-help-text').style.display = this.value === 'flex' ? 'block' : 'none';
+});
+</script>
+</div>

--- a/app/Views/line-oa/templates-index.php
+++ b/app/Views/line-oa/templates-index.php
@@ -1,0 +1,115 @@
+<?php
+$pageTitle = 'LINE OA — Templates';
+$lang = (isset($_SESSION['lang']) && $_SESSION['lang'] == 1) ? 'th' : 'en';
+$isThai = ($lang === 'th');
+$labels = [
+    'en' => [
+        'page_title' => 'Message Templates',
+        'new'        => 'New Template',
+        'name'       => 'Name',
+        'type'       => 'Type',
+        'message_kind' => 'Kind',
+        'languages'  => 'Languages',
+        'active'     => 'Active',
+        'actions'    => 'Actions',
+        'edit'       => 'Edit',
+        'delete'     => 'Delete',
+        'no_templates' => 'No templates yet. Create your first one to start sending rich messages.',
+        'confirm_delete' => 'Delete this template?',
+        'yes'        => 'Yes',
+        'no'         => 'No',
+    ],
+    'th' => [
+        'page_title' => 'เทมเพลตข้อความ',
+        'new'        => 'สร้างเทมเพลต',
+        'name'       => 'ชื่อ',
+        'type'       => 'ประเภท',
+        'message_kind' => 'รูปแบบ',
+        'languages'  => 'ภาษา',
+        'active'     => 'ใช้งาน',
+        'actions'    => 'จัดการ',
+        'edit'       => 'แก้ไข',
+        'delete'     => 'ลบ',
+        'no_templates' => 'ยังไม่มีเทมเพลต สร้างเทมเพลตแรกเพื่อส่งข้อความรูปแบบสวยงาม',
+        'confirm_delete' => 'ลบเทมเพลตนี้?',
+        'yes'        => 'ใช่',
+        'no'         => 'ไม่ใช่',
+    ],
+];
+$t = $labels[$lang];
+
+$typeLabels = [
+    'tour_package'     => $isThai ? 'แพ็คเกจทัวร์'  : 'Tour Package',
+    'quotation'        => $isThai ? 'ใบเสนอราคา'   : 'Quotation',
+    'booking_confirm'  => $isThai ? 'ยืนยันการจอง' : 'Booking Confirm',
+    'payment_reminder' => $isThai ? 'แจ้งชำระเงิน' : 'Payment Reminder',
+    'voucher'          => $isThai ? 'วอเชอร์'      : 'Voucher',
+    'custom'           => $isThai ? 'อื่นๆ'         : 'Custom',
+];
+?>
+<?php $currentNavPage = 'line_templates'; include __DIR__ . '/_nav.php'; ?>
+
+<?php if (!empty($_SESSION['flash_success'])): ?>
+<div class="alert alert-success alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_success'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_success']); endif; ?>
+<?php if (!empty($_SESSION['flash_error'])): ?>
+<div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_error']); endif; ?>
+
+<div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:15px; flex-wrap:wrap; gap:10px;">
+        <h4 style="margin:0;"><i class="fa fa-clone"></i> <?= $t['page_title'] ?></h4>
+        <a href="index.php?page=line_template_edit" class="btn btn-success btn-sm">
+            <i class="fa fa-plus"></i> <?= $t['new'] ?>
+        </a>
+    </div>
+
+    <?php if (empty($templates)): ?>
+        <p style="text-align:center; padding:40px 20px; color:#999;"><?= $t['no_templates'] ?></p>
+    <?php else: ?>
+    <div class="table-responsive">
+        <table class="table table-hover" style="margin:0;">
+            <thead>
+                <tr>
+                    <th><?= $t['name'] ?></th>
+                    <th><?= $t['type'] ?></th>
+                    <th><?= $t['message_kind'] ?></th>
+                    <th><?= $t['languages'] ?></th>
+                    <th><?= $t['active'] ?></th>
+                    <th style="text-align:right;"><?= $t['actions'] ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($templates as $tpl): ?>
+                <tr>
+                    <td><strong><?= htmlspecialchars($tpl['name'], ENT_QUOTES, 'UTF-8') ?></strong></td>
+                    <td><span class="label label-info"><?= htmlspecialchars($typeLabels[$tpl['template_type']] ?? $tpl['template_type'], ENT_QUOTES, 'UTF-8') ?></span></td>
+                    <td><code><?= htmlspecialchars($tpl['message_type'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                    <td>
+                        <?php if (!empty($tpl['content_th'])): ?><span class="label label-default">TH</span><?php endif; ?>
+                        <?php if (!empty($tpl['content_en'])): ?><span class="label label-default">EN</span><?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($tpl['is_active']): ?>
+                            <span class="label label-success"><?= $t['yes'] ?></span>
+                        <?php else: ?>
+                            <span class="label label-default"><?= $t['no'] ?></span>
+                        <?php endif; ?>
+                    </td>
+                    <td style="text-align:right;">
+                        <a href="index.php?page=line_template_edit&amp;id=<?= (int)$tpl['id'] ?>" class="btn btn-xs btn-outline-primary"><i class="fa fa-pencil"></i> <?= $t['edit'] ?></a>
+                        <form method="POST" action="index.php?page=line_template_save" style="display:inline;" onsubmit="return confirm('<?= $t['confirm_delete'] ?>');">
+                            <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="id" value="<?= (int)$tpl['id'] ?>">
+                            <button type="submit" class="btn btn-xs btn-outline-danger"><i class="fa fa-trash"></i></button>
+                        </form>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <?php endif; ?>
+</div>
+</div>

--- a/cron.php
+++ b/cron.php
@@ -15,6 +15,7 @@
  *   sync_all_contracts   — one-time/periodic full sync of all V2 operator contracts
  *                          to all assigned agents (rebuilds tour_operator_agent_products)
  *   run_worker           — drain one task from task_queue (v6.1 #76); schedule every minute
+ *   process_broadcasts   — v6.3 LINE OA: send any due-scheduled broadcasts; schedule every 5–10 min
  *
  * Auth: ?token=... must match config['cron_token'] (set via env or config file)
  *
@@ -82,9 +83,12 @@ switch ($task) {
     case 'run_worker':
         require_once __DIR__ . '/scripts/worker.php';
         break;
+    case 'process_broadcasts':
+        runProcessBroadcasts();
+        break;
     default:
         http_response_code(400);
-        echo "Unknown task. Available: daily_reports, weekly_reports, monthly_reports, sync_all_contracts, run_worker\n";
+        echo "Unknown task. Available: daily_reports, weekly_reports, monthly_reports, sync_all_contracts, run_worker, process_broadcasts\n";
         exit;
 }
 
@@ -142,6 +146,118 @@ function runReports(string $period): void
     }
 
     echo "\nSummary: $sent sent, $failed failed, $skipped skipped.\n";
+}
+
+function runProcessBroadcasts(): void
+{
+    require_once __DIR__ . '/app/Models/LineOA.php';
+    require_once __DIR__ . '/app/Models/LineMessaging.php';
+    require_once __DIR__ . '/app/Services/LineService.php';
+    require_once __DIR__ . '/app/Controllers/LineOAController.php';
+
+    // Spoof a session-less context for the controller (it normally reads $this->user)
+    // We bypass the constructor's auth by calling dispatchBroadcast() directly per-tenant.
+    $msgModel = new \App\Models\LineMessaging();
+    $lineModel = new \App\Models\LineOA();
+    $due = $msgModel->findDueBroadcasts(20);
+
+    if (empty($due)) {
+        echo "No due broadcasts.\n";
+        return;
+    }
+
+    $totalSent = 0;
+    $totalFailed = 0;
+
+    foreach ($due as $b) {
+        $companyId = (int)$b['company_id'];
+        $broadcastId = (int)$b['id'];
+        $config = $lineModel->getConfig($companyId);
+        if (!$config || empty($config['channel_access_token'])) {
+            $msgModel->updateBroadcastStatus($broadcastId, $companyId, 'failed', ['last_error' => 'No LINE credentials']);
+            echo "  - SKIP broadcast #$broadcastId (company $companyId): no credentials\n";
+            continue;
+        }
+
+        $msgModel->updateBroadcastStatus($broadcastId, $companyId, 'sending', ['mark_started' => true]);
+
+        $service = new \App\Services\LineService(
+            (string)$config['channel_access_token'],
+            (string)$config['channel_secret']
+        );
+
+        // Build messages from the broadcast row
+        $messages = buildBroadcastMessagesFromRow($msgModel, $b, $companyId);
+        if (empty($messages)) {
+            $msgModel->updateBroadcastStatus($broadcastId, $companyId, 'failed', ['last_error' => 'Empty message payload']);
+            echo "  - FAIL broadcast #$broadcastId: empty message\n";
+            continue;
+        }
+
+        $sent = 0;
+        $failed = 0;
+        $lastError = null;
+
+        while (true) {
+            $chunk = $msgModel->getPendingRecipientChunk($broadcastId, $companyId, 500);
+            if (empty($chunk)) break;
+            $userIds = array_column($chunk, 'line_user_id');
+            $rowIds  = array_column($chunk, 'recipient_row_id');
+            $resp = $service->multicast($userIds, $messages);
+
+            if ($resp['success'] ?? false) {
+                $msgModel->markRecipientsSent($rowIds, $companyId);
+                $sent += count($rowIds);
+            } else {
+                $err = $resp['message'] ?? ($resp['error'] ?? 'Unknown error');
+                $msgModel->markRecipientsFailed($rowIds, $companyId, $err);
+                $failed += count($rowIds);
+                $lastError = $err;
+                if (in_array((int)($resp['http_code'] ?? 0), [401, 403])) break;
+            }
+        }
+
+        $finalStatus = $failed === 0 ? 'sent' : ($sent > 0 ? 'partial' : 'failed');
+        $msgModel->updateBroadcastStatus($broadcastId, $companyId, $finalStatus, [
+            'sent_count'     => $sent,
+            'failed_count'   => $failed,
+            'last_error'     => $lastError,
+            'mark_completed' => true,
+        ]);
+
+        echo "  - DONE broadcast #$broadcastId (company $companyId): $sent sent, $failed failed\n";
+        $totalSent += $sent;
+        $totalFailed += $failed;
+    }
+
+    echo "\nSummary: " . count($due) . " broadcasts processed, $totalSent sent, $totalFailed failed.\n";
+}
+
+function buildBroadcastMessagesFromRow(\App\Models\LineMessaging $msgModel, array $b, int $companyId): array
+{
+    // Cron has no session — pick TH if Thai content exists, else EN.
+    $isThai = !empty($b['text_content_th']) || !empty($b['flex_content_th']);
+
+    switch ($b['message_kind']) {
+        case 'template':
+            $tpl = $msgModel->getTemplate((int)$b['template_id'], $companyId);
+            if (!$tpl) return [];
+            $r = $msgModel->renderTemplate($tpl, [], $isThai);
+            if ($r['type'] === 'text') return [['type' => 'text', 'text' => $r['text']]];
+            return [['type' => 'flex', 'altText' => $r['alt_text'] ?: 'Message', 'contents' => $r['contents']]];
+
+        case 'custom_flex':
+            $flexJson = $isThai ? ($b['flex_content_th'] ?? $b['flex_content_en']) : ($b['flex_content_en'] ?? $b['flex_content_th']);
+            $contents = json_decode((string)$flexJson, true);
+            if (!$contents) return [];
+            return [['type' => 'flex', 'altText' => $b['alt_text'] ?: 'Message', 'contents' => $contents]];
+
+        case 'text':
+        default:
+            $text = $isThai ? ($b['text_content_th'] ?? $b['text_content_en']) : ($b['text_content_en'] ?? $b['text_content_th']);
+            if (empty($text)) return [];
+            return [['type' => 'text', 'text' => (string)$text]];
+    }
 }
 
 function runSyncAllContracts(): void

--- a/database/migrations/2026_05_06_line_oa_v6_3_rich_messaging.sql
+++ b/database/migrations/2026_05_06_line_oa_v6_3_rich_messaging.sql
@@ -1,0 +1,214 @@
+-- Migration: 2026_05_06_line_oa_v6_3_rich_messaging.sql
+-- v6.3 — LINE OA Rich Messaging
+-- Adds: Flex message templates, Broadcast campaigns + recipients, User tags, bot-info cache
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+-- Idempotent: safe to run multiple times via stored-procedure column/index checks
+
+-- =============================================================================
+-- 1. line_message_templates — bilingual Flex/text message templates
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS line_message_templates (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    company_id INT NOT NULL,
+    name VARCHAR(150) NOT NULL,
+    template_type ENUM('tour_package','quotation','booking_confirm','payment_reminder','voucher','custom') DEFAULT 'custom',
+    message_type ENUM('text','flex') DEFAULT 'flex',
+    alt_text VARCHAR(400) DEFAULT NULL COMMENT 'Notification fallback text',
+    content_th TEXT DEFAULT NULL COMMENT 'Thai version: text body OR Flex JSON',
+    content_en TEXT DEFAULT NULL COMMENT 'English version: text body OR Flex JSON',
+    variables_json TEXT DEFAULT NULL COMMENT 'JSON array of variable names like ["tour_name","price"]',
+    is_active TINYINT(1) DEFAULT 1,
+    created_by INT DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at DATETIME DEFAULT NULL,
+    INDEX idx_company (company_id),
+    INDEX idx_type (template_type),
+    INDEX idx_active (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- =============================================================================
+-- 2. line_user_tags — segmentation tags per company
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS line_user_tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    company_id INT NOT NULL,
+    name VARCHAR(80) NOT NULL,
+    color VARCHAR(20) DEFAULT '#3498db',
+    description VARCHAR(255) DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_at DATETIME DEFAULT NULL,
+    INDEX idx_company (company_id),
+    UNIQUE KEY uk_company_name (company_id, name, deleted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- =============================================================================
+-- 3. line_user_tag_map — pivot: line_users <-> line_user_tags
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS line_user_tag_map (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    company_id INT NOT NULL,
+    line_user_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_company (company_id),
+    INDEX idx_line_user (line_user_id),
+    INDEX idx_tag (tag_id),
+    UNIQUE KEY uk_user_tag (line_user_id, tag_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- =============================================================================
+-- 4. line_broadcasts — campaign records (one per send/scheduled send)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS line_broadcasts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    company_id INT NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    status ENUM('draft','scheduled','sending','sent','partial','failed','cancelled') DEFAULT 'draft',
+
+    -- Audience selector
+    audience_type ENUM('all','tag','language','has_booked','last_active') DEFAULT 'all',
+    audience_filter_json TEXT DEFAULT NULL COMMENT 'JSON: {tag_id, language, days, ...}',
+    recipient_count INT DEFAULT 0 COMMENT 'Snapshot count at time of send',
+
+    -- Message payload
+    message_kind ENUM('text','template','custom_flex') DEFAULT 'text',
+    template_id INT DEFAULT NULL COMMENT 'FK to line_message_templates if message_kind=template',
+    text_content_th TEXT DEFAULT NULL,
+    text_content_en TEXT DEFAULT NULL,
+    flex_content_th TEXT DEFAULT NULL,
+    flex_content_en TEXT DEFAULT NULL,
+    alt_text VARCHAR(400) DEFAULT NULL,
+
+    -- Schedule
+    scheduled_at DATETIME DEFAULT NULL,
+    sent_started_at DATETIME DEFAULT NULL,
+    sent_completed_at DATETIME DEFAULT NULL,
+
+    -- Results
+    sent_count INT DEFAULT 0,
+    failed_count INT DEFAULT 0,
+    last_error TEXT DEFAULT NULL,
+
+    created_by INT DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at DATETIME DEFAULT NULL,
+    INDEX idx_company (company_id),
+    INDEX idx_status (status),
+    INDEX idx_scheduled (scheduled_at),
+    INDEX idx_template (template_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- =============================================================================
+-- 5. line_broadcast_recipients — per-user delivery log for each broadcast
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS line_broadcast_recipients (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    company_id INT NOT NULL,
+    broadcast_id INT NOT NULL,
+    line_user_id INT NOT NULL,
+    status ENUM('pending','sent','failed','skipped') DEFAULT 'pending',
+    error_message VARCHAR(500) DEFAULT NULL,
+    sent_at DATETIME DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_company (company_id),
+    INDEX idx_broadcast (broadcast_id),
+    INDEX idx_line_user (line_user_id),
+    INDEX idx_status (status),
+    UNIQUE KEY uk_broadcast_user (broadcast_id, line_user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- =============================================================================
+-- 6. ALTER line_oa_config — add bot-info cache columns (idempotent)
+-- =============================================================================
+DROP PROCEDURE IF EXISTS _migrate_line_v63_alters;
+DELIMITER $$
+CREATE PROCEDURE _migrate_line_v63_alters()
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'bot_display_name'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `bot_display_name` VARCHAR(255) DEFAULT NULL AFTER `rich_menu_id`;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'bot_picture_url'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `bot_picture_url` VARCHAR(500) DEFAULT NULL AFTER `bot_display_name`;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'bot_basic_id'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `bot_basic_id` VARCHAR(80) DEFAULT NULL AFTER `bot_picture_url`;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'last_probe_at'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `last_probe_at` DATETIME DEFAULT NULL AFTER `bot_basic_id`;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'last_probe_status'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `last_probe_status` ENUM('connected','invalid_credentials','unreachable','unknown') DEFAULT 'unknown' AFTER `last_probe_at`;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'last_probe_error'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `last_probe_error` VARCHAR(500) DEFAULT NULL AFTER `last_probe_status`;
+    END IF;
+
+    -- Monthly broadcast quota tracking (LINE free-tier = 500/month)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_oa_config'
+          AND COLUMN_NAME  = 'broadcast_quota_monthly'
+    ) THEN
+        ALTER TABLE `line_oa_config` ADD COLUMN `broadcast_quota_monthly` INT DEFAULT 500 AFTER `last_probe_error`;
+    END IF;
+END$$
+DELIMITER ;
+CALL _migrate_line_v63_alters();
+DROP PROCEDURE IF EXISTS _migrate_line_v63_alters;
+
+-- =============================================================================
+-- 7. Seed default templates per company (idempotent — only inserts if missing)
+-- =============================================================================
+-- Note: tour operators can edit these after first save. JSON is the LINE Flex
+-- bubble structure; placeholders like {tour_name} are interpolated at send time.
+INSERT INTO line_message_templates (company_id, name, template_type, message_type, alt_text, content_th, content_en, variables_json, is_active)
+SELECT c.id, 'Tour Package Card', 'tour_package', 'flex',
+       'Tour package: {tour_name}',
+       '{"type":"bubble","hero":{"type":"image","url":"{image_url}","size":"full","aspectRatio":"20:13","aspectMode":"cover"},"body":{"type":"box","layout":"vertical","contents":[{"type":"text","text":"{tour_name}","weight":"bold","size":"xl","wrap":true},{"type":"text","text":"ราคา ฿{price}","color":"#06C755","weight":"bold","size":"lg","margin":"md"},{"type":"text","text":"{description}","wrap":true,"size":"sm","color":"#666666","margin":"md"}]},"footer":{"type":"box","layout":"vertical","contents":[{"type":"button","style":"primary","color":"#06C755","action":{"type":"uri","label":"จองเลย","uri":"{book_url}"}}]}}',
+       '{"type":"bubble","hero":{"type":"image","url":"{image_url}","size":"full","aspectRatio":"20:13","aspectMode":"cover"},"body":{"type":"box","layout":"vertical","contents":[{"type":"text","text":"{tour_name}","weight":"bold","size":"xl","wrap":true},{"type":"text","text":"From ฿{price}","color":"#06C755","weight":"bold","size":"lg","margin":"md"},{"type":"text","text":"{description}","wrap":true,"size":"sm","color":"#666666","margin":"md"}]},"footer":{"type":"box","layout":"vertical","contents":[{"type":"button","style":"primary","color":"#06C755","action":{"type":"uri","label":"Book Now","uri":"{book_url}"}}]}}',
+       '["tour_name","price","description","image_url","book_url"]',
+       1
+FROM company c
+WHERE c.id > 0
+  AND NOT EXISTS (
+    SELECT 1 FROM line_message_templates t
+    WHERE t.company_id = c.id AND t.template_type = 'tour_package' AND t.deleted_at IS NULL
+  );


### PR DESCRIPTION
## Summary

Turns LINE OA from a passive inbox into a sales channel for tour operators.

- **#110 Real channel health probe** — `/v2/bot/info` with 60s DB cache, 3 states (Connected / Invalid credentials / Unreachable), bot name+picture on dashboard.
- **#111 Bilingual Flex templates** — `{variable}` substitution at render time, TH+EN per template, tour-package template seeded per company.
- **#112 Broadcast campaigns** — 3-step composer (Audience → Message → Schedule), 500-chunk multicast, scheduled send via `cron.php?task=process_broadcasts`, quota meter.
- **#113 Quota enforcement** — blocks `send_now`/`schedule` when `monthly_used + audience > broadcast_quota_monthly`. Drafts always allowed.

Closes #110 #111 #112 #113

## Schema additions

| Table / column | Purpose |
|---|---|
| `line_message_templates` | Bilingual Flex/text templates |
| `line_broadcasts` | Campaign records |
| `line_broadcast_recipients` | Per-user delivery rows (retry/audit) |
| `line_user_tags` + `line_user_tag_map` | Audience segmentation |
| `line_oa_config.bot_*` (3 cols) | Cached bot display name / picture / basic_id |
| `line_oa_config.last_probe_*` (3 cols) | Probe state cache |
| `line_oa_config.broadcast_quota_monthly` | Per-tenant quota |

Migration: `database/migrations/2026_05_06_line_oa_v6_3_rich_messaging.sql` — idempotent (stored-procedure column checks), MySQL 5.7 / cPanel safe.

## Test plan

- [ ] **Migration**: import via phpMyAdmin on staging; verify 5 new tables + 7 new columns exist; tour_package template seeded for all companies.
- [ ] **Health probe**: dashboard ↻ Re-test → 🟢 Connected with bot name. Save bogus token → 🟡 Invalid credentials.
- [ ] **Templates**: create/edit/soft-delete a template; bilingual content saves; variables JSON round-trips.
- [ ] **Broadcasts — send-now**: 1,200-recipient broadcast chunks into 3 multicast calls; `sent_count=1200`.
- [ ] **Broadcasts — schedule**: register `*/5 * * * * curl ... process_broadcasts`. Schedule a broadcast for `NOW()+2m`. Verify it dispatches.
- [ ] **Quota**: company with `broadcast_quota_monthly=500`, used=400, audience=200 → send_now blocked with named error. Draft still saves.
- [ ] **Multi-tenant**: company B navigates to company A's `line_template_edit&id=X` → "Template not found" redirect.
- [ ] **CSRF**: POST without token → 403.
- [ ] **Bilingual UI**: switch to Thai → all v6.3 pages render in Thai (page titles, audience labels, status badges).
- [ ] **Mobile 320px**: compose page columns stack; all controls usable.

## Deploy notes (for DevOps)

1. Import migration via phpMyAdmin (staging then prod).
2. Upload 14 files via cPanel File Manager.
3. Add cron: `*/5 * * * * curl -fsS "https://iacc.f2.co.th/cron.php?task=process_broadcasts&token=$CRON_TOKEN" >> ~/logs/cron-broadcasts.log 2>&1`
4. Verify `Asia/Bangkok` timezone (scheduled-broadcast correctness).
5. Verify outbound HTTPS to `api.line.me` from cPanel host.

## Out-of-scope (post-v6.3 follow-ups)

- JSON validation on Flex template save (QA-002, Low)
- Mask access-token textarea on Settings (Sec-Low-#1, pre-existing)
- Live Flex preview pane on template editor
- LIFF mini-app + Rich Menu management → planned for v6.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
