### PR TITLE
fix(line-oa): send-message form always failed validation due to userId/id mismatch

### DIFF
--- a/app/Views/line-oa/send-message.php
+++ b/app/Views/line-oa/send-message.php
@@ -62,7 +62,7 @@ $t = $labels[$lang];
                         <select name="line_user_id" class="form-control" required>
                             <option value="">-- <?= $t['select_user'] ?> --</option>
                             <?php foreach ($lineUsers as $u): ?>
-                            <option value="<?= $u['line_user_id'] ?>"><?= htmlspecialchars($u['display_name'] ?: $u['line_user_id'], ENT_QUOTES, 'UTF-8') ?></option>
+                            <option value="<?= (int)$u['id'] ?>"><?= htmlspecialchars($u['display_name'] ?: $u['line_user_id'], ENT_QUOTES, 'UTF-8') ?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>


### PR DESCRIPTION
## Summary

The Send Message form has never worked. Submitting it always fell through to "User and message are required." even when both were filled in.

## Root cause

[`send-message.php:65`](app/Views/line-oa/send-message.php#L65) emitted the LINE userId string as the option value:

```php
<option value="<?= $u['line_user_id'] ?>">  <!-- e.g. "Uabc123def..." -->
```

But [`LineOAController.php:372`](app/Controllers/LineOAController.php#L372) reads it as an int:

```php
$lineUserDbId = intval($_POST['line_user_id'] ?? 0);  // intval("Uabc...") = 0
```

`intval()` on a string that doesn't start with digits returns 0, so `getLineUserById(0)` always returned null → controller redirected with the validation flash.

## Fix

One line: emit `(int)$u['id']` (the DB primary key) as the option value to match what the controller expects. Display label is unchanged.

## Test plan

- [ ] Open `index.php?page=line_send_message` on staging.
- [ ] Pick a LINE user from the dropdown, type "test" in the message box, click Send.
- [ ] Expect: flash success "Message sent successfully." and a row in `line_messages` with `direction='outbound'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
