### PR TITLE
chore(tracker): sync version.json commit hash to main merge sha (32d6b83)

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "6.2-line-oa-rich-messaging",
-  "commit": "5e70a0d",
-  "commit_short": "5e70a0d",
+  "commit": "32d6b83",
+  "commit_short": "32d6b83",
   "branch": "main",
   "build_date": "2026-05-06T17:46:00+07:00",
   "environment": "production",


### PR DESCRIPTION
Cosmetic follow-up to v6.2-line-oa-rich-messaging release. version.json's `commit`/`commit_short` were pre-stamped at `5e70a0d` (develop tip at bump time); the convention is to point to the actual main merge commit. Version string unchanged so the README↔json sync check still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)