### PR TITLE
fix(v6.3): #120 — point matchTour at the real model table

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -252,7 +252,8 @@ class LineAgentController extends BaseController
     // ====================================================================
 
     /**
-     * Fuzzy match a tour name against the company's `tour_products`.
+     * Fuzzy match a tour name against the company's `model` table
+     * (joined with `type` so agents can match by category name too).
      * Returns ['status' => 'none'|'one'|'multiple', 'tour' => array|null, 'candidates' => array]
      */
     private static function matchTour(int $companyId, string $needle): array
@@ -262,16 +263,19 @@ class LineAgentController extends BaseController
         if ($needle === '') return ['status' => 'none', 'tour' => null, 'candidates' => []];
 
         $stmt = $db->conn->prepare(
-            "SELECT id, tour_name AS name
-             FROM tour_products
-             WHERE company_id = ?
-               AND deleted_at IS NULL
-               AND (tour_name LIKE CONCAT('%', ?, '%')
-                    OR ? LIKE CONCAT('%', tour_name, '%'))
-             ORDER BY CHAR_LENGTH(tour_name) ASC
+            "SELECT m.id, m.model_name AS name
+             FROM model m
+             LEFT JOIN type t ON m.type_id = t.id
+             WHERE m.company_id = ?
+               AND m.deleted_at IS NULL
+               AND m.is_active = 1
+               AND (m.model_name LIKE CONCAT('%', ?, '%')
+                    OR ? LIKE CONCAT('%', m.model_name, '%')
+                    OR t.name LIKE CONCAT('%', ?, '%'))
+             ORDER BY CHAR_LENGTH(m.model_name) ASC
              LIMIT 5"
         );
-        $stmt->bind_param('iss', $companyId, $needle, $needle);
+        $stmt->bind_param('isss', $companyId, $needle, $needle, $needle);
         $stmt->execute();
         $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
         $stmt->close();


### PR DESCRIPTION
## Summary

Hotfix for [#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) / PR #124. The merged controller queried `tour_products`, a table that doesn't exist anywhere in iACC — every agent text booking would have failed at the tour-lookup step on staging.

## Root cause

While implementing #120 I picked the wrong table name. The rest of iACC looks up tours via `model` joined with `type` (see [`TourBooking::searchProducts`](app/Models/TourBooking.php#L761)). Caught during the staging pre-flight (`SHOW COLUMNS FROM tour_products` → `#1146 — Table 'f2coth_dev.tour_products' doesn't exist`).

## Change

Single function: `LineAgentController::matchTour()`.

- Switched the SELECT from `tour_products` → `model m LEFT JOIN type t`
- Added `m.is_active = 1` (matches `searchProducts` behavior)
- Added a third LIKE clause on `t.name` so agents can match by category as well as model name
- Bound-param string `iss` → `isss` for the extra placeholder
- Kept prepared statements (the existing `searchProducts` interpolates — not replicating that)

No migration impact. The #120 migration is already applied and unaffected.

## Verification

- `php -l` clean inside `iacc_php` (PHP 7.4.33)
- Query prepared + bound + executed against the local `iacc` DB without errors
- Returned 0 rows for `needle="tour"` (expected — local seed has no matching `model` row), confirming the SQL plan is valid

## Test plan

- [ ] Re-deploy staging from develop
- [ ] Verify `model` and `type` tables exist on `f2coth_dev` (they should — they're part of master-data)
- [ ] Bind a LINE agent (per #124 plan)
- [ ] Send the locked TH/EN template with a real `model_name` from staging — expect success Flex with booking number
- [ ] Send with a non-existent tour name — expect `tour_not_found` reply
- [ ] Send with a partial name that matches multiple models — expect numbered disambiguation list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
