### PR TITLE
fix(v6.3): #120 — pin matchTour LIKE collation

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -262,6 +262,11 @@ class LineAgentController extends BaseController
         $needle = trim($needle);
         if ($needle === '') return ['status' => 'none', 'tour' => null, 'candidates' => []];
 
+        // CONVERT + COLLATE on each bound parameter pins the LIKE comparison to
+        // utf8mb4_unicode_ci regardless of the server's `collation_connection`.
+        // Without this, MySQL throws "Illegal mix of collations" when the
+        // connection collation (e.g. utf8mb4_bin on staging) differs from the
+        // column collation (utf8mb4_unicode_ci).
         $stmt = $db->conn->prepare(
             "SELECT m.id, m.model_name AS name
              FROM model m
@@ -269,9 +274,9 @@ class LineAgentController extends BaseController
              WHERE m.company_id = ?
                AND m.deleted_at IS NULL
                AND m.is_active = 1
-               AND (m.model_name LIKE CONCAT('%', ?, '%')
-                    OR ? LIKE CONCAT('%', m.model_name, '%')
-                    OR t.name LIKE CONCAT('%', ?, '%'))
+               AND (m.model_name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%')
+                    OR CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', m.model_name, '%')
+                    OR t.name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%'))
              ORDER BY CHAR_LENGTH(m.model_name) ASC
              LIMIT 5"
         );


### PR DESCRIPTION
## Summary

Third hotfix on the [#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) trail. Staging webhook returned **total silence** on every agent text-booking attempt — caught by reading `line_webhook_events`:

```
Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
and (utf8mb4_bin,NONE) for operation 'like'
```

## Root cause

`model.model_name` and `type.name` are `utf8mb4_unicode_ci`. Staging's `collation_connection` server default is `utf8mb4_bin`. Bound parameters arrive at the server in the connection's collation, so the `LIKE` between `?` (utf8mb4_bin) and the column (utf8mb4_unicode_ci) is unreconcilable → MySQL throws at execute time.

`processEvent`'s outer try/catch swallows the throw, logs it to `line_webhook_events`, returns 200 to LINE, and the user sees nothing. Local Docker MySQL didn't surface the bug because its connection collation happens to match the columns.

## Change

Single function: `LineAgentController::matchTour()`. Each of the three bound parameters is wrapped with `CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci` so the LIKE compares in a known collation regardless of server defaults.

```sql
m.model_name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%')
```

No migration. No call-site changes. `bind_param` signature unchanged (`isss`).

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container
- Re-ran the exact prepare + bind + execute against local DB — prepares + executes without error
- Local would have already worked under either collation; staging is the actual test of this fix

## Test plan (staging)

- [ ] Re-deploy from develop
- [ ] Re-send the locked TH/EN booking template via LINE — expect ✅ green Flex with `TB-YYYYMMDD-NNN`
- [ ] If the row is missing or you still get silence: re-pull `line_webhook_events` to check for any new error rows
- [ ] Verify a row in `tour_bookings` with `created_via='line_oa_agent_text'`

## Defense-in-depth (deferred)

`matchTour` and `generateBookingNumber` aren't wrapped in try/catch inside `ingestText`. Any DB error from those still results in silence instead of a user-facing reply. Worth a follow-up: wrap the whole `ingestText` body so the user always gets an error Flex (and we don't need to dig through webhook logs to diagnose). Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
