### PR TITLE
fix(v6.3): #120 — use canonical BK-YYMMDD-NNN booking number

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -191,8 +191,6 @@ class LineAgentController extends BaseController
         // Past-date warning prefix for the reply (still write the booking)
         $pastDateWarn = $parser::isDatePast($fields['date']);
 
-        $bookingNumber = self::generateBookingNumber($companyId);
-
         // Compose remark — captures the tour name (line item is added later via web UI) +
         // any agent notes + agent_code provenance
         $remarkParts = [];
@@ -202,30 +200,33 @@ class LineAgentController extends BaseController
         if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
         $remark = implode("\n", $remarkParts);
 
-        $bookingData = [
-            'company_id'     => $companyId,
-            'booking_number' => $bookingNumber,
-            'booking_date'   => date('Y-m-d'),
-            'travel_date'    => $fields['date'],
-            'agent_id'       => 0,
-            'sales_rep_id'   => 0,
-            'customer_id'    => 0,
-            'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
-            'pax_adult'      => (int)$fields['adults'],
-            'pax_child'      => (int)($fields['children'] ?? 0),
-            'pax_infant'     => 0,
-            'status'         => 'pending',
-            'remark'         => $remark,
-            'created_by'     => $iaccUserId,
-            'created_via'    => 'line_oa_agent_text',
-        ];
-
         try {
             $tourBookingModel = new \App\Models\TourBooking();
+            $bookingNumber = $tourBookingModel->generateBookingNumber($companyId);
+
+            $bookingData = [
+                'company_id'     => $companyId,
+                'booking_number' => $bookingNumber,
+                'booking_date'   => date('Y-m-d'),
+                'travel_date'    => $fields['date'],
+                'agent_id'       => 0,
+                'sales_rep_id'   => 0,
+                'customer_id'    => 0,
+                'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
+                'pax_adult'      => (int)$fields['adults'],
+                'pax_child'      => (int)($fields['children'] ?? 0),
+                'pax_infant'     => 0,
+                'status'         => 'pending',
+                'remark'         => $remark,
+                'created_by'     => $iaccUserId,
+                'created_via'    => 'line_oa_agent_text',
+            ];
+
             $bookingId = $tourBookingModel->createBooking($bookingData);
         } catch (\Throwable $e) {
             error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
             $bookingId = 0;
+            $bookingNumber = '';
         }
 
         if ($bookingId <= 0) {
@@ -288,27 +289,6 @@ class LineAgentController extends BaseController
         if (empty($rows))    return ['status' => 'none',     'tour' => null,    'candidates' => []];
         if (count($rows) === 1) return ['status' => 'one',  'tour' => $rows[0],'candidates' => $rows];
         return ['status' => 'multiple', 'tour' => null, 'candidates' => $rows];
-    }
-
-    private static function generateBookingNumber(int $companyId): string
-    {
-        // Mirrors existing convention: TB-YYYYMMDD-NNN per company per day
-        global $db;
-        $today = date('Ymd');
-        $prefix = 'TB-' . $today . '-';
-
-        $stmt = $db->conn->prepare(
-            "SELECT COUNT(*) AS cnt FROM tour_bookings
-             WHERE company_id = ? AND booking_number LIKE ?"
-        );
-        $like = $prefix . '%';
-        $stmt->bind_param('is', $companyId, $like);
-        $stmt->execute();
-        $row = $stmt->get_result()->fetch_assoc();
-        $stmt->close();
-
-        $next = ((int)($row['cnt'] ?? 0)) + 1;
-        return $prefix . str_pad((string)$next, 3, '0', STR_PAD_LEFT);
     }
 
     // ----- Flex / text reply builders -----


### PR DESCRIPTION
## Summary

Fourth hotfix on the [#120](https://github.com/psinthorn/issues/120) trail. The merged controller minted booking numbers as `TB-YYYYMMDD-NNN`, which diverges from the rest of iACC's `BK-YYMMDD-NNN` convention. Caught by manual review of the smoke-test output expectation.

## Change

| Before | After |
|---|---|
| `TB-20260507-001` (controller-local generator, `COUNT(*)+1`) | `BK-260507-001` (canonical `TourBooking::generateBookingNumber()`) |

Single change to `LineAgentController::ingestText()`:

- Replaced the in-controller static `generateBookingNumber` with `$tourBookingModel->generateBookingNumber($companyId)` — the same method the web booking form uses, so all bookings (web, LINE, future channels) share one numbering scheme.
- The canonical method increments from the **last** booking_number for that company on that day rather than from `COUNT(*)`, so a soft-deleted row (or any future hard delete) won't create a duplicate.
- Moved booking-number generation + data composition inside the existing `try/catch`, so any DB error in either step now lands in the `write_failed` reply branch instead of triggering the silence-and-bury-in-logs pattern we just fixed in #127. Closes the deferred defense-in-depth note I left in #127's body.
- Deleted the now-dead static helper (−22 lines).

No migration. No new model methods. Net diff: +21 / −41.

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container
- `grep` confirms no other call sites of the removed static helper

## Test plan (staging)

- [ ] Re-deploy from develop
- [ ] Re-send the locked TH/EN booking template via LINE — expect ✅ green Flex with `BK-YYMMDD-NNN`
- [ ] Verify `tour_bookings` row has `booking_number` matching that format and `created_via='line_oa_agent_text'`
- [ ] If you create another booking from the web UI same day, the LINE-created one and the web-created one should fall on the same per-day counter sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
