### PR TITLE
fix(v6.3): #120 — match status enum, log write errors to webhook log

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -216,7 +216,7 @@ class LineAgentController extends BaseController
                 'pax_adult'      => (int)$fields['adults'],
                 'pax_child'      => (int)($fields['children'] ?? 0),
                 'pax_infant'     => 0,
-                'status'         => 'pending',
+                'status'         => 'draft',
                 'remark'         => $remark,
                 'created_by'     => $iaccUserId,
                 'created_via'    => 'line_oa_agent_text',
@@ -225,6 +225,17 @@ class LineAgentController extends BaseController
             $bookingId = $tourBookingModel->createBooking($bookingData);
         } catch (\Throwable $e) {
             error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
+            // Also persist to line_webhook_events so the same error is visible
+            // via SQL on cPanel without having to read PHP error logs.
+            try {
+                $line->logWebhookEvent($companyId, 'error', json_encode([
+                    'context' => 'agent_booking_write',
+                    'error'   => $e->getMessage(),
+                    'fields'  => $fields ?? [],
+                ]));
+            } catch (\Throwable $_) {
+                // logging is best-effort; never let it mask the original error
+            }
             $bookingId = 0;
             $bookingNumber = '';
         }


### PR DESCRIPTION
## Summary

Fifth (and hopefully final) hotfix on the [#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) trail. Live LINE smoke test on staging returned the structured "write_failed" reply ("เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ"), meaning the parser, trigger, tour-match, and binding lookup all succeeded — only the actual `tour_bookings` INSERT failed.

## Root cause

`ingestText` set `'status' => 'pending'` on the booking data. But:

```sql
SHOW COLUMNS FROM tour_bookings LIKE 'status';
-- enum('draft','confirmed','completed','cancelled')
```

`'pending'` is not in the enum. MySQL truncates / errors on the INSERT, the existing try/catch swallows it, and the user gets the generic `write_failed` reply with no detail. The web booking form (`TourBookingController::store`) uses `'draft'` for new bookings — that's the canonical default.

## Change

| Before | After |
|---|---|
| `'status' => 'pending'` | `'status' => 'draft'` |
| Catch only writes to PHP `error_log()` | Catch *also* appends a row to `line_webhook_events` with `event_type='error'` and the `$e->getMessage()` payload |

Why the second change: PHP `error_log` is awkward on cPanel. `line_webhook_events` is one phpMyAdmin query away — the exact place where you found the collation bug in PR #127. Future write errors show up there immediately, no SSH or log-file digging.

The webhook-log write is wrapped in its own try/catch so a failure there can never mask the underlying error.

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container
- Local Docker schema confirms the enum: `enum('draft','confirmed','completed','cancelled')`

## Test plan (staging)

- [ ] Re-deploy from develop
- [ ] Re-send the locked TH/EN booking template — expect ✅ green Flex with `BK-260507-NNN` (or whatever today's date is on the test)
- [ ] Verify a row in `tour_bookings` with `status='draft'`, `created_via='line_oa_agent_text'`, `booking_number` matching `BK-YYMMDD-NNN`
- [ ] If anything still fails, the new `line_webhook_events` row will name the column / constraint that's blocking it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
