### PR TITLE
feat(v6.3): #120 — accept short trigger จอง / book when paired with anchors

### DIFF
--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -34,10 +34,23 @@ namespace App\Models;
  */
 class AgentBookingParser
 {
-    // Trigger phrases (any one anywhere in the message activates parsing)
-    private const TRIGGERS = [
+    // Trigger phrases (case-insensitive substring match anywhere in the message).
+    //
+    // Strong triggers always activate the agent intercept — useful so an empty
+    // template still gets the validation Flex listing the missing fields.
+    //
+    // Weak triggers only activate when the message also contains at least one
+    // structured field anchor (ทัวร์:, date:, etc.). Otherwise we let the
+    // legacy "book/จอง <date> <time>" customer handler in line-webhook.php
+    // keep handling them — that flow is for non-agent customers and is
+    // unrelated to agent text-template booking.
+    private const TRIGGERS_STRONG = [
         'th' => ['จองทัวร์'],
         'en' => ['book tour'],
+    ];
+    private const TRIGGERS_WEAK = [
+        'th' => ['จอง'],
+        'en' => ['book'],
     ];
 
     // Field-keyword aliases (TH and EN); first match wins per language
@@ -65,7 +78,10 @@ class AgentBookingParser
         $lang    = self::detectLang($message);
         $trigger = self::detectTrigger($message);
 
-        if ($trigger === null) {
+        // No trigger at all, OR a weak trigger with no field anchor — let
+        // the legacy customer-date handler keep handling the message.
+        if ($trigger === null
+            || (!$trigger['strong'] && !self::hasAnyAnchor($message))) {
             return [
                 'ok'              => false,
                 'fields'          => [],
@@ -83,7 +99,7 @@ class AgentBookingParser
             'fields'          => $fields,
             'errors'          => $errors,
             'lang'            => $lang,
-            'matched_trigger' => $trigger,
+            'matched_trigger' => $trigger['phrase'],
         ];
     }
 
@@ -97,15 +113,46 @@ class AgentBookingParser
         return preg_match('/[\x{0E00}-\x{0E7F}]/u', $message) ? 'th' : 'en';
     }
 
-    private static function detectTrigger(string $message): ?string
+    /**
+     * Returns ['phrase' => string, 'strong' => bool] or null if no trigger
+     * is found. Strong triggers are unconditional; weak triggers must be
+     * paired with a field anchor (see hasAnyAnchor) to count.
+     */
+    private static function detectTrigger(string $message): ?array
     {
         $haystack = mb_strtolower($message);
-        foreach (self::TRIGGERS as $lang => $phrases) {
+        foreach (self::TRIGGERS_STRONG as $lang => $phrases) {
             foreach ($phrases as $p) {
-                if (mb_stripos($haystack, $p) !== false) return $p;
+                if (mb_stripos($haystack, $p) !== false) {
+                    return ['phrase' => $p, 'strong' => true];
+                }
+            }
+        }
+        foreach (self::TRIGGERS_WEAK as $lang => $phrases) {
+            foreach ($phrases as $p) {
+                if (mb_stripos($haystack, $p) !== false) {
+                    return ['phrase' => $p, 'strong' => false];
+                }
             }
         }
         return null;
+    }
+
+    /**
+     * True if the message contains at least one "<field-keyword>:" anchor.
+     * Used to distinguish a structured agent template from a bare legacy
+     * command like "book 2026-04-15 14:00".
+     */
+    private static function hasAnyAnchor(string $message): bool
+    {
+        foreach (self::FIELD_KEYWORDS as $keywords) {
+            foreach ($keywords as $kw) {
+                if (preg_match('/' . preg_quote($kw, '/') . '\s*[:：]/ui', $message)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     // ============================================================


### PR DESCRIPTION
## Summary

Lets agents type the shorter `จอง` or `book` (instead of `จองทัวร์` / `book tour`) to enter the agent text-template flow — without breaking the existing customer-facing legacy `book/จอง <date> <time>` handler in `line-webhook.php`.

Asked for during the [#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) staging smoke test ("it will be good if working both if จอง and จองทัวร์").

## Design — strong vs weak triggers

| Trigger | Type | Behavior |
|---|---|---|
| `จองทัวร์`, `book tour` | **Strong** | Unconditional agent intercept. Even empty templates get the validation Flex listing missing fields. |
| `จอง`, `book` | **Weak** | Agent intercept only if the message also contains a structured field anchor (`ทัวร์:`, `date:`, etc.). Otherwise → `no_trigger`, falls through to the legacy handler. |

Naively adding `จอง` / `book` as triggers would have broken customer date bookings (`จอง 2026-06-15 14:00` would be eaten by the parser and replied with a "missing fields" Flex). The anchor-required gate fixes that.

## Behavior matrix

| Message | Path |
|---|---|
| `จองทัวร์` (alone) | agent intercept → validation Flex with missing-fields list |
| `จอง 2026-06-15 14:00` | legacy date handler (**unchanged**) |
| `จอง\nทัวร์: SM-EN-01-AT\n…` | agent intercept |
| `Book\nTour: SM-EN-01-AT\n…` | agent intercept (case-insensitive) |
| `BOOK\nTOUR: X\n…` | agent intercept (case-insensitive) |
| `จองคิว tomorrow 3pm` | legacy (unchanged) |
| `hello there` | falls through to default reply |

## Verification

Ran the parser against 9 edge cases inside the `iacc_php` PHP 7.4 container:

```
[validation_failed:...] strong TH alone
[no_trigger]            weak TH no anchor — legacy handles
[OK]                    weak TH + anchors
[validation_failed:...] strong EN alone
[no_trigger]            weak EN no anchor
[OK]                    weak EN capitalized + anchors
[OK]                    weak EN UPPERCASE + anchors
[no_trigger]            no trigger at all
[no_trigger]            weak TH (จอง substring) no anchor
```

All 9 cases match expected behavior. `php -l` clean.

## Test plan (staging)

- [ ] Re-deploy from develop
- [ ] `จองทัวร์\nทัวร์: SM-EN-01-AT\n…` — full template → green Flex with `BK-260507-NNN` (regression check, should still work)
- [ ] `จอง\nทัวร์: SM-EN-01-AT\n…` — short trigger + full template → green Flex
- [ ] `Book\nTour: SM-EN-01-AT\n…` — case-insensitive EN → green Flex
- [ ] `จอง 2026-06-15 14:00` — bare legacy customer command → "Please provide a valid date and time. Format: book 2026-04-15 14:00" (legacy handler still working)
- [ ] `จอง smoke` — single-word jibberish → falls through to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
