### PR TITLE
fix(v6.3): #120 — load inc/security.php in webhook bootstrap

### DIFF
--- a/line-webhook.php
+++ b/line-webhook.php
@@ -27,6 +27,12 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/inc/sys.configs.php';
 require_once __DIR__ . '/inc/class.dbconn.php';
 require_once __DIR__ . '/inc/class.hard.php';
+// inc/security.php — needed by App\Models\TourBooking::createBooking and other
+// model methods that use sql_escape() / sql_int() / sql_float(). The normal
+// page bootstrap (index.php) loads this; the webhook bootstrap was missing it,
+// which caused a fatal "Call to undefined function sql_escape()" inside
+// agent text-template booking writes.
+require_once __DIR__ . '/inc/security.php';
 
 // Autoloader for App namespace
 spl_autoload_register(function ($class) {


### PR DESCRIPTION
## Summary

Sixth fix on the [#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) trail — and the actual root cause behind the "write_failed" reply we've been chasing.

The error logging added in #129 caught it on the first try:

```json
{
  "context":"agent_booking_write",
  "error":"Call to undefined function App\\Models\\sql_escape()",
  ...
}
```

## Root cause

`inc/security.php` defines `sql_escape()`, `sql_int()`, `sql_float()` and other helpers that `TourBooking::createBooking` interpolates into its INSERT SQL. `index.php` loads `inc/security.php` at line 57 during normal page bootstrap. **`line-webhook.php` was missing it.**

The fatal landed inside the agent booking write path, was caught by the try/catch added in #129, and logged to `line_webhook_events` — exactly the diagnostic loop we built earlier paying off.

## Change

One line added to `line-webhook.php`'s bootstrap:

```php
require_once __DIR__ . '/inc/security.php';
```

`inc/security.php` is pure function definitions with no top-level side effects (no `session_start()`, no DB calls, no global mutation), so the require is safe in any context — including the webhook, which deliberately keeps its bootstrap minimal (no session, no module-helper).

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container
- Verified the helpers list — `sql_escape`, `sql_int`, `sql_float`, plus dozens more — none of which conflict with anything already loaded in webhook context
- Confirmed file has no top-level side effects: opens with `<?php` then jumps straight into `function csrf_token() {…}`

## Test plan (staging)

- [ ] Re-deploy from develop
- [ ] Send `จองทัวร์` template via LINE — expect ✅ green Flex with `BK-260507-NNN`
- [ ] Verify a row in `tour_bookings` with `status='draft'`, `created_via='line_oa_agent_text'`
- [ ] Verify a NEW row in `line_webhook_events` with `event_type='message'` (no `error` row)
- [ ] If still write_failed, the new error row will name the next missing dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
