### PR TITLE
feat(v6.3): #132 — booking_by + tour_booking_contacts + allotment-aware status

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -191,38 +191,81 @@ class LineAgentController extends BaseController
         // Past-date warning prefix for the reply (still write the booking)
         $pastDateWarn = $parser::isDatePast($fields['date']);
 
-        // Compose remark — captures the tour name (line item is added later via web UI) +
-        // any agent notes + agent_code provenance
+        // Resolve the bound user's display name for booking_by (was the
+        // customer name+phone before #132 — semantically wrong).
+        $boundUser = $line->getBoundUserDetails($companyId, $lineUserIdStr);
+        $bookingByName = $boundUser['authorize_name']
+            ?? ('LINE bound user #' . $iaccUserId);
+
+        // Compose remark — captures the tour name + any agent notes +
+        // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id
+        // is deferred to #136 once the bind UI supports agent-tenant users).
         $remarkParts = [];
         $remarkParts[] = '[from LINE agent text]';
         $remarkParts[] = 'Tour: ' . ($tour['name'] ?? '');
-        if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code: ' . $fields['agent_code'];
+        if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code (typed): ' . $fields['agent_code'];
         if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
         $remark = implode("\n", $remarkParts);
 
+        $statusInfo = ['status' => 'draft', 'reason' => 'unresolved'];
         try {
             $tourBookingModel = new \App\Models\TourBooking();
             $bookingNumber = $tourBookingModel->generateBookingNumber($companyId);
+
+            // Allotment-aware status (auto-confirm if seats available)
+            $totalPax = (int)$fields['adults'] + (int)($fields['children'] ?? 0);
+            $statusInfo = $tourBookingModel->resolveBookingStatus(
+                $companyId, $fields['date'], $totalPax
+            );
 
             $bookingData = [
                 'company_id'     => $companyId,
                 'booking_number' => $bookingNumber,
                 'booking_date'   => date('Y-m-d'),
                 'travel_date'    => $fields['date'],
-                'agent_id'       => 0,
+                'agent_id'       => 0, // deferred to #136
                 'sales_rep_id'   => 0,
                 'customer_id'    => 0,
-                'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
+                'booking_by'     => $bookingByName,
                 'pax_adult'      => (int)$fields['adults'],
                 'pax_child'      => (int)($fields['children'] ?? 0),
                 'pax_infant'     => 0,
-                'status'         => 'draft',
+                'pickup_hotel'   => $fields['accommodation'] ?? '',
+                'pickup_room'    => $fields['room'] ?? '',
+                'status'         => $statusInfo['status'],
                 'remark'         => $remark,
-                'created_by'     => $iaccUserId,
+                'created_by'     => $boundUser['authorize_id'] ?? $iaccUserId,
                 'created_via'    => 'line_oa_agent_text',
             ];
 
             $bookingId = $tourBookingModel->createBooking($bookingData);
+
+            // Per-booking customer contact row (proper home for name +
+            // mobile + email + messenger, replacing the "stuff into booking_by"
+            // placeholder from the original #120 PR).
+            if ($bookingId > 0) {
+                $tourBookingModel->saveBookingContact($bookingId, [
+                    'contact_name'       => $fields['customer_name']  ?? '',
+                    'mobile'             => $fields['customer_mobile'] ?? '',
+                    'email'              => $fields['email']          ?? '',
+                    'contact_messengers' => $fields['messenger']      ?? '',
+                ]);
+
+                // Visibility: log a webhook event when status fell to draft
+                // due to allotment so the operator can act on it.
+                if ($statusInfo['status'] === 'draft' && $statusInfo['reason'] !== 'unresolved') {
+                    try {
+                        $line->logWebhookEvent($companyId, 'allotment_blocked', json_encode([
+                            'context'        => 'agent_booking_status_resolved',
+                            'booking_id'     => $bookingId,
+                            'booking_number' => $bookingNumber,
+                            'travel_date'    => $fields['date'],
+                            'pax'            => $totalPax,
+                            'reason'         => $statusInfo['reason'],
+                        ]));
+                    } catch (\Throwable $_) {}
+                }
+            }
         } catch (\Throwable $e) {
             error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
             // Also persist to line_webhook_events so the same error is visible
@@ -255,7 +298,7 @@ class LineAgentController extends BaseController
             'handled'        => true,
             'reason'         => 'booked',
             'booking_id'     => $bookingId,
-            'reply_messages' => [self::buildSuccessFlex($bookingNumber, $tour, $fields, $lang, $pastDateWarn)],
+            'reply_messages' => [self::buildSuccessFlex($bookingNumber, $tour, $fields, $lang, $pastDateWarn, $statusInfo)],
         ];
     }
 
@@ -310,33 +353,70 @@ class LineAgentController extends BaseController
         return ['type' => 'text', 'text' => $text];
     }
 
-    private static function buildSuccessFlex(string $bookingNumber, array $tour, array $fields, string $lang, bool $pastDateWarn): array
+    private static function buildSuccessFlex(string $bookingNumber, array $tour, array $fields, string $lang, bool $pastDateWarn, array $statusInfo = ['status' => 'confirmed', 'reason' => 'available']): array
     {
         $isThai = ($lang === 'th');
-        $title  = $isThai ? '✅ ยืนยันการจอง' : '✅ Booking Confirmed';
+        $confirmed = ($statusInfo['status'] ?? 'confirmed') === 'confirmed';
+
+        if ($confirmed) {
+            $title = $isThai ? '✅ ยืนยันการจอง' : '✅ Booking Confirmed';
+            $titleColor = '#06C755';
+        } else {
+            $title = $isThai ? '⏳ รอการตรวจสอบ' : '⏳ Booking Pending Review';
+            $titleColor = '#e67e22';
+        }
         if ($pastDateWarn) $title .= $isThai ? ' ⚠️ (วันที่ผ่านมาแล้ว)' : ' ⚠️ (past date)';
+
+        // Sub-line explaining why a confirmed booking went to draft.
+        $subLine = '';
+        if (!$confirmed) {
+            $reasonMap = [
+                'no_allotment' => $isThai ? 'ยังไม่มีการตั้งค่าจำนวนที่นั่งสำหรับวันนี้' : 'No allotment configured for this date',
+                'closed'       => $isThai ? 'วันที่นี้ถูกปิดรับการจอง'                  : 'This date is closed for booking',
+                'overbook'     => $isThai ? 'จำนวนที่นั่งไม่เพียงพอ'                    : 'Not enough seats available',
+            ];
+            $subLine = $reasonMap[$statusInfo['reason'] ?? ''] ?? '';
+        }
 
         $paxLine = ($isThai
             ? sprintf('👥 %d ผู้ใหญ่ + %d เด็ก', (int)$fields['adults'], (int)($fields['children'] ?? 0))
             : sprintf('👥 %d adults + %d children', (int)$fields['adults'], (int)($fields['children'] ?? 0)));
 
+        $rows = [
+            ['type' => 'text', 'text' => $title, 'weight' => 'bold', 'size' => 'lg', 'color' => $titleColor, 'wrap' => true],
+            ['type' => 'text', 'text' => $bookingNumber, 'size' => 'sm', 'color' => '#888888', 'margin' => 'sm'],
+        ];
+        if ($subLine !== '') {
+            $rows[] = ['type' => 'text', 'text' => $subLine, 'size' => 'xs', 'color' => '#888888', 'margin' => 'sm', 'wrap' => true];
+        }
+        $rows[] = ['type' => 'separator', 'margin' => 'md'];
+        $rows[] = ['type' => 'text', 'text' => $tour['name'] ?? '', 'weight' => 'bold', 'size' => 'md', 'wrap' => true, 'margin' => 'md'];
+        $rows[] = ['type' => 'text', 'text' => '📅 ' . $fields['date'], 'size' => 'sm', 'margin' => 'sm'];
+        $rows[] = ['type' => 'text', 'text' => $paxLine, 'size' => 'sm', 'margin' => 'sm'];
+        $rows[] = ['type' => 'text', 'text' => '👤 ' . ($fields['customer_name'] ?? ''), 'size' => 'sm', 'margin' => 'sm', 'wrap' => true];
+        $rows[] = ['type' => 'text', 'text' => '📱 ' . ($fields['customer_mobile'] ?? ''), 'size' => 'sm', 'margin' => 'sm'];
+        if (!empty($fields['email'])) {
+            $rows[] = ['type' => 'text', 'text' => '✉️ ' . $fields['email'], 'size' => 'sm', 'margin' => 'sm', 'wrap' => true];
+        }
+        if (!empty($fields['accommodation'])) {
+            $rows[] = ['type' => 'text', 'text' => '🏨 ' . $fields['accommodation'], 'size' => 'sm', 'margin' => 'sm', 'wrap' => true];
+        }
+        if (!empty($fields['room'])) {
+            $rows[] = ['type' => 'text', 'text' => ($isThai ? '🚪 ห้อง ' : '🚪 Room ') . $fields['room'], 'size' => 'sm', 'margin' => 'sm'];
+        }
+
+        $altPrefix = $confirmed
+            ? ($isThai ? 'ยืนยันการจอง '      : 'Booking confirmed ')
+            : ($isThai ? 'การจองรอตรวจสอบ ' : 'Booking pending review ');
+
         return [
             'type' => 'flex',
-            'altText' => ($isThai ? 'ยืนยันการจอง ' : 'Booking confirmed ') . $bookingNumber,
+            'altText' => $altPrefix . $bookingNumber,
             'contents' => [
                 'type' => 'bubble',
                 'body' => [
                     'type' => 'box', 'layout' => 'vertical',
-                    'contents' => [
-                        ['type' => 'text', 'text' => $title, 'weight' => 'bold', 'size' => 'lg', 'color' => '#06C755', 'wrap' => true],
-                        ['type' => 'text', 'text' => $bookingNumber, 'size' => 'sm', 'color' => '#888888', 'margin' => 'sm'],
-                        ['type' => 'separator', 'margin' => 'md'],
-                        ['type' => 'text', 'text' => $tour['name'] ?? '', 'weight' => 'bold', 'size' => 'md', 'wrap' => true, 'margin' => 'md'],
-                        ['type' => 'text', 'text' => '📅 ' . $fields['date'], 'size' => 'sm', 'margin' => 'sm'],
-                        ['type' => 'text', 'text' => $paxLine, 'size' => 'sm', 'margin' => 'sm'],
-                        ['type' => 'text', 'text' => '👤 ' . ($fields['customer_name'] ?? ''), 'size' => 'sm', 'margin' => 'sm', 'wrap' => true],
-                        ['type' => 'text', 'text' => '📞 ' . ($fields['customer_phone'] ?? ''), 'size' => 'sm', 'margin' => 'sm'],
-                    ],
+                    'contents' => $rows,
                 ],
             ],
         ];
@@ -350,8 +430,8 @@ class LineAgentController extends BaseController
             'date_missing'      => $isThai ? 'วันที่ / date'           : 'date / วันที่',
             'date_invalid'      => $isThai ? 'รูปแบบวันที่ (YYYY-MM-DD)' : 'date format (YYYY-MM-DD)',
             'adults_missing'    => $isThai ? 'ผู้ใหญ่ / adults'         : 'adults / ผู้ใหญ่',
-            'customer_missing'  => $isThai ? 'ลูกค้า ชื่อ + เบอร์'       : 'customer name + phone',
-            'agent_code_missing'=> $isThai ? 'ตัวแทน / agent'         : 'agent / ตัวแทน',
+            'customer_missing'  => $isThai ? 'ลูกค้า / customer name'   : 'customer / ลูกค้า',
+            'mobile_missing'    => $isThai ? 'มือถือ / mobile'         : 'mobile / มือถือ',
             'phone_invalid'     => $isThai ? 'เบอร์โทรไม่ถูกต้อง'        : 'phone number invalid',
             'pax_too_few'       => $isThai ? 'จำนวนผู้เดินทางต้อง ≥ 1'   : 'pax must be ≥ 1',
         ];

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -2,33 +2,45 @@
 namespace App\Models;
 
 /**
- * AgentBookingParser — v6.3 #120
+ * AgentBookingParser — v6.3 #120 / #132
  *
- * Stateless parser that converts an inbound LINE OA text message from a
- * sales agent into a structured booking record (or a list of validation
- * errors).
+ * Stateless parser that converts an inbound LINE OA text message from an
+ * agent (or, after v6.6, a direct customer) into a structured booking
+ * record — or a list of validation errors.
  *
- * Locked schema (PM call 2026-05-06, see issue #120):
+ * Schema (current — updated in #132):
  *
- *   จองทัวร์    OR    book tour
- *   ทัวร์: <tour_name>           |   tour: <tour_name>
- *   วันที่: <YYYY-MM-DD>         |   date: <YYYY-MM-DD>
- *   ผู้ใหญ่: <int>               |   adults: <int>
- *   เด็ก: <int>                  |   children: <int>
- *   ลูกค้า: <name> <phone>       |   customer: <name> <phone>
- *   ตัวแทน: <agent_code>         |   agent: <agent_code>
- *   หมายเหตุ: <free text>         |   notes: <free text>
+ *   จองทัวร์    OR    book tour                          (strong trigger)
+ *   จอง        OR    book                              (weak trigger — only when paired with field anchors)
  *
- * Required: tour, date, adults, customer, agent.
- * Optional: children, notes.
+ *   ทัวร์: <model_name>             |   tour: <model_name>             (required)
+ *   วันที่ (Travel Date): <YYYY-MM-DD>|   date (Travel Date): <YYYY-MM-DD> (required)
+ *   ผู้ใหญ่: <int>                  |   adults: <int>                  (required)
+ *   เด็ก: <int>                     |   children: <int>                (optional)
+ *   ลูกค้า: <name>                  |   customer: <name>               (required)
+ *   มือถือ: <phone>                 |   mobile: <phone>                (required if ลูกค้า: has no trailing digits)
+ *   อีเมล: <email>                  |   email: <email>                 (optional)
+ *   เมสเซนเจอร์: <id>               |   messenger: <id>                (optional, e.g. line:foo or @bar)
+ *   ตัวแทน: <code>                  |   agent: <code>                  (optional — captured into remark for audit; auto-resolution to agent_id is tracked in #136)
+ *   ที่พัก: <name>                   |   accommodation: <name>          (optional → tour_bookings.pickup_hotel)
+ *   หมายเลขห้อง: <id>                |   room: <id>                     (optional → tour_bookings.pickup_room)
+ *   หมายเหตุ: <free text>            |   notes: <free text>             (optional)
+ *
+ * Backward compatibility: if `ลูกค้า:` includes a trailing phone-like token
+ * and `มือถือ:` is NOT provided, the trailing digits are split off as the
+ * mobile number. This preserves the original v6.3 #120 single-line format.
+ *
+ * Customer contact (name, mobile, email, messenger) is persisted to
+ * `tour_booking_contacts` (not `tour_bookings.booking_by`) — the latter is
+ * reserved for the iACC user who entered the booking.
  *
  * Usage:
  *   $result = AgentBookingParser::parse($messageText);
  *   if ($result['ok']) {
- *       $fields = $result['fields'];   // ['tour_name'=>..., 'date'=>..., 'adults'=>4, ...]
+ *       $fields = $result['fields'];   // ['tour_name'=>..., 'customer_mobile'=>..., 'accommodation'=>..., ...]
  *       $lang   = $result['lang'];     // 'th' | 'en'
  *   } else {
- *       $errors = $result['errors'];   // ['date_missing', 'phone_invalid', ...]
+ *       $errors = $result['errors'];   // ['date_missing', 'phone_invalid', 'mobile_missing', ...]
  *       $lang   = $result['lang'];
  *   }
  */
@@ -60,11 +72,19 @@ class AgentBookingParser
         'adults'         => ['ผู้ใหญ่', 'adults'],
         'children'       => ['เด็ก', 'children'],
         'customer'       => ['ลูกค้า', 'customer'],
+        'mobile'         => ['มือถือ', 'mobile'],
+        'email'          => ['อีเมล', 'email'],
+        'messenger'      => ['เมสเซนเจอร์', 'messenger'],
         'agent_code'     => ['ตัวแทน', 'agent'],
+        'accommodation'  => ['ที่พัก', 'accommodation'],
+        'room'           => ['หมายเลขห้อง', 'room'],
         'notes'          => ['หมายเหตุ', 'notes'],
     ];
 
-    private const REQUIRED_FIELDS = ['tour_name', 'date', 'adults', 'customer', 'agent_code'];
+    // agent_code is no longer required — auto-resolution from the LINE binding
+    // is tracked in #136. Customer phone comes from explicit `มือถือ:` /
+    // `mobile:` keyword (preferred) or trailing digits in `ลูกค้า:` (fallback).
+    private const REQUIRED_FIELDS = ['tour_name', 'date', 'adults', 'customer'];
 
     /**
      * Returns:
@@ -196,12 +216,23 @@ class AgentBookingParser
         // Default children=0 if not provided (optional field)
         $fields['children'] = $fields['children'] ?? 0;
 
-        // Customer field is "<name> <phone>" — split on last whitespace before
-        // a phone-like token so names with spaces work.
+        // Customer field handling:
+        // - If `มือถือ:` / `mobile:` is provided, treat `ลูกค้า:` as the name only.
+        // - Otherwise fall back to the legacy split: `ลูกค้า: <name> <phone>`.
+        // Either way, `customer_mobile` becomes the canonical phone for downstream
+        // validation and persistence.
         if (isset($fields['customer'])) {
-            $split = self::splitCustomer($fields['customer']);
-            $fields['customer_name']  = $split['name'];
-            $fields['customer_phone'] = $split['phone'];
+            $explicitMobile = trim($fields['mobile'] ?? '');
+            if ($explicitMobile !== '') {
+                $fields['customer_name']   = trim($fields['customer']);
+                $fields['customer_phone']  = '';
+                $fields['customer_mobile'] = $explicitMobile;
+            } else {
+                $split = self::splitCustomer($fields['customer']);
+                $fields['customer_name']   = $split['name'];
+                $fields['customer_phone']  = $split['phone'];
+                $fields['customer_mobile'] = $split['phone'];
+            }
         }
 
         return $fields;
@@ -258,8 +289,11 @@ class AgentBookingParser
 
         foreach (self::REQUIRED_FIELDS as $req) {
             if ($req === 'customer') {
-                if (empty($f['customer_name']) || empty($f['customer_phone'])) {
+                if (empty($f['customer_name'])) {
                     $errors[] = 'customer_missing';
+                }
+                if (empty($f['customer_mobile'])) {
+                    $errors[] = 'mobile_missing';
                 }
                 continue;
             }
@@ -279,7 +313,7 @@ class AgentBookingParser
             if ($totalPax < 1) $errors[] = 'pax_too_few';
         }
 
-        if (!empty($f['customer_phone']) && !self::isValidPhone($f['customer_phone'])) {
+        if (!empty($f['customer_mobile']) && !self::isValidPhone($f['customer_mobile'])) {
             $errors[] = 'phone_invalid';
         }
 

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -274,6 +274,35 @@ class LineOA extends BaseModel
     }
 
     /**
+     * v6.3 #132 — Lookup the bound iACC user's authorize record for a given
+     * LINE userId string. Returns ['authorize_id', 'authorize_name', 'email']
+     * or null if the LINE user isn't bound (or isn't user_type='agent').
+     *
+     * Used so the booking write can populate `tour_bookings.booking_by` with
+     * the human-readable identity of the agent who entered the booking,
+     * instead of the customer's name+phone (the placeholder bug from #120).
+     */
+    public function getBoundUserDetails(int $companyId, string $lineUserIdStr): ?array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email
+             FROM line_users u
+             JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             WHERE u.company_id = ?
+               AND u.line_user_id = ?
+               AND u.user_type = 'agent'
+               AND u.linked_user_id IS NOT NULL
+               AND u.deleted_at IS NULL
+             LIMIT 1"
+        );
+        $stmt->bind_param('is', $companyId, $lineUserIdStr);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ?: null;
+    }
+
+    /**
      * v6.3 #120 — Lookup the bound iACC user id for a given LINE userId string.
      * Returns null if the LINE user isn't an agent or isn't bound.
      */

--- a/app/Models/TourBooking.php
+++ b/app/Models/TourBooking.php
@@ -9,6 +9,31 @@ class TourBooking extends BaseModel
     // ─── Booking Number ────────────────────────────────────────
 
     /**
+     * Resolve a booking's `status` based on tour_allotments availability.
+     * Centralized so every booking write path (web form, LINE agent text,
+     * LINE customer direct in v6.6, future channels) reaches the same
+     * verdict from the same data.
+     *
+     * Returns ['status' => 'confirmed'|'draft', 'reason' => 'available'|'no_allotment'|'closed'|'overbook'].
+     *
+     * Decision matrix:
+     *   - No allotment configured for the date  → 'draft' / 'no_allotment'
+     *   - Allotment row exists but is_closed=1  → 'draft' / 'closed'
+     *   - requestedPax > available              → 'draft' / 'overbook'
+     *   - Otherwise                             → 'confirmed' / 'available'
+     */
+    public function resolveBookingStatus(int $companyId, string $travelDate, int $requestedPax): array
+    {
+        $allotmentModel = new \App\Models\TourAllotment();
+        $alloc = $allotmentModel->getAllotmentByDate($companyId, $travelDate);
+
+        if (!$alloc)                                   return ['status' => 'draft',     'reason' => 'no_allotment'];
+        if (!empty($alloc['is_closed']))               return ['status' => 'draft',     'reason' => 'closed'];
+        if ($requestedPax > intval($alloc['available'])) return ['status' => 'draft',   'reason' => 'overbook'];
+        return ['status' => 'confirmed', 'reason' => 'available'];
+    }
+
+    /**
      * Generate next booking number: BK-YYMMDD-001
      */
     public function generateBookingNumber(int $comId): string


### PR DESCRIPTION
Closes [#132](https://github.com/psinthorn/iacc-php-mvc/issues/132). The follow-up to v6.3 #120 that replaces placeholder field-mapping with proper semantics, captures customer contact in the right table, populates hotel/room columns, and introduces a shared allotment-aware booking-status resolver that v6.6 (#134) will reuse.

## Summary

| Surface | Change |
|---|---|
| `tour_bookings.booking_by` | Bound iACC user's display name (was: customer name + phone — semantically wrong, visible to admins) |
| `tour_bookings.pickup_hotel`, `pickup_room` | Populated from new `ที่พัก:` / `accommodation:` and `หมายเลขห้อง:` / `room:` keywords |
| `tour_booking_contacts` | New child row per booking with contact_name + mobile + email + contact_messengers |
| `tour_bookings.status` | Resolved by new `TourBooking::resolveBookingStatus()` consulting `TourAllotment::getAllotmentByDate` — auto-`confirmed` when seats available, auto-`draft` otherwise |
| `tour_bookings.agent_id` | Stays NULL in v1 — auto-resolve deferred to **#136** (requires extending bind UI to support agent-tenant users) |
| Parser | 5 new keywords (`มือถือ/mobile`, `อีเมล/email`, `เมสเซนเจอร์/messenger`, `ที่พัก/accommodation`, `หมายเลขห้อง/room`); `ตัวแทน:` no longer required (captured into remark for audit) |
| Success Flex | Differentiates ✅ Confirmed vs ⏳ Pending Review with bilingual reason; separate name/mobile lines; email/hotel/room rows when present |
| Diagnostics | When status falls to draft due to allotment, log `event_type='allotment_blocked'` to `line_webhook_events` for operator visibility |

## Files

| File | Δ |
|---|---|
| `app/Models/AgentBookingParser.php` | +50 / −12 — keywords, customer_mobile normalization, validation, updated docblock |
| `app/Models/LineOA.php` | +29 — new `getBoundUserDetails()` |
| `app/Models/TourBooking.php` | +25 — new `resolveBookingStatus()` |
| `app/Controllers/LineAgentController.php` | +90 / −24 — wire booking_by, contacts insert, status resolver, success Flex layout, allotment_blocked logging |

## Backward compatibility

The original v6.3 #120 single-line customer format still parses — when `มือถือ:` is **not** provided, `ลูกค้า: <name> <phone>` falls back to the existing trailing-digit split heuristic. Verified locally:

```
[OK] regression: original #120 7-field format
  tour_name = SM-EN-01-AT
  customer_name = คุณทดสอบ
  customer_mobile = 0812345678   ← extracted via legacy split
  agent_code = TEST001
```

## Allotment status resolver — used by

- LINE agent booking write (this PR)
- LINE customer-direct booking write (v6.6 #134, future)
- Web booking form (potential future migration — out of scope for this PR)

## Test plan (staging)

### Parser regression
- [ ] Original v6.3 template (`จองทัวร์` + 7 fields with `ลูกค้า: <name> <phone>` combined) → still works, mobile extracted via legacy split
- [ ] Same template with `มือถือ:` added explicitly → mobile comes from `มือถือ:`, name is just from `ลูกค้า:`

### New fields → DB
- [ ] Send template with `ที่พัก: Banyan Tree` and `หมายเลขห้อง: 1001` → verify `tour_bookings.pickup_hotel='Banyan Tree'`, `pickup_room='1001'`
- [ ] Same template with `อีเมล: test@example.com` and `เมสเซนเจอร์: line:test` → verify `tour_booking_contacts` row with `email`, `contact_messengers` populated
- [ ] `tour_booking_contacts.contact_name` matches the agent-typed name; `mobile` matches the resolved canonical mobile

### booking_by
- [ ] `tour_bookings.booking_by` shows the bound iACC user's name (your name when binding to yourself), not the customer's
- [ ] Booking detail page renders correctly with the new value

### Allotment-aware status
- [ ] Send a booking for a date with NO allotment → expect `status='draft'`, ⏳ Pending Review Flex with reason "No allotment configured for this date"
- [ ] Set up an allotment with available seats → send same booking → expect `status='confirmed'`, ✅ Booking Confirmed Flex
- [ ] Set up an allotment, close the date → send booking → expect `status='draft'`, ⏳ with reason "This date is closed for booking"
- [ ] Set up an allotment with 1 seat available → send booking with adults=2 → expect `status='draft'`, ⏳ with reason "Not enough seats available"
- [ ] In all draft cases, verify `line_webhook_events` has a row with `event_type='allotment_blocked'` and the reason

### Validation
- [ ] Send template missing `มือถือ:` and with `ลูกค้า: คุณทดสอบ` (no trailing digits) → orange Flex listing `customer / ลูกค้า` AND `mobile / มือถือ`
- [ ] Send template with `ลูกค้า: คุณทดสอบ 0812345678` (trailing digits, no `มือถือ:`) → still passes

### Backward
- [ ] Legacy `book 2026-06-15 14:00` (v6.2 customer flow) still works — does NOT hit the agent intercept

## Out of scope (deferred)

- `tour_bookings.agent_id` auto-resolution → **#136** (requires bind UI extension)
- v6.4 self-serve template editor → **#133**
- v6.6 customer-direct booking + Flex carousel → **#134, #135**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
