### PR TITLE
fix(v6.3): #132 — booking_by uses bound user's name (or email) reliably

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -193,9 +193,21 @@ class LineAgentController extends BaseController
 
         // Resolve the bound user's display name for booking_by (was the
         // customer name+phone before #132 — semantically wrong).
+        // Priority: name → email → bare "User #ID" sentinel. Empty strings
+        // (not just nulls) also fall through, since some authorize rows have
+        // name='' rather than NULL.
         $boundUser = $line->getBoundUserDetails($companyId, $lineUserIdStr);
-        $bookingByName = $boundUser['authorize_name']
-            ?? ('LINE bound user #' . $iaccUserId);
+        $bookingByName = '';
+        if ($boundUser) {
+            if (!empty($boundUser['authorize_name'])) {
+                $bookingByName = $boundUser['authorize_name'];
+            } elseif (!empty($boundUser['email'])) {
+                $bookingByName = $boundUser['email'];
+            }
+        }
+        if ($bookingByName === '') {
+            $bookingByName = 'User #' . $iaccUserId;
+        }
 
         // Compose remark — captures the tour name + any agent notes +
         // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -275,19 +275,23 @@ class LineOA extends BaseModel
 
     /**
      * v6.3 #132 — Lookup the bound iACC user's authorize record for a given
-     * LINE userId string. Returns ['authorize_id', 'authorize_name', 'email']
+     * LINE userId string. Returns ['authorize_id', 'authorize_name', 'email', 'phone']
      * or null if the LINE user isn't bound (or isn't user_type='agent').
      *
      * Used so the booking write can populate `tour_bookings.booking_by` with
      * the human-readable identity of the agent who entered the booking,
      * instead of the customer's name+phone (the placeholder bug from #120).
+     *
+     * The JOIN deliberately does NOT constrain `authorize.company_id` —
+     * tenancy is already enforced by `bindAgentToUser` at bind time, and
+     * #136 will extend bindings to agent-tenant users (different com_id).
      */
     public function getBoundUserDetails(int $companyId, string $lineUserIdStr): ?array
     {
         $stmt = $this->conn->prepare(
-            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email
+            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email, a.phone
              FROM line_users u
-             JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             JOIN authorize a ON a.id = u.linked_user_id
              WHERE u.company_id = ?
                AND u.line_user_id = ?
                AND u.user_type = 'agent'


### PR DESCRIPTION
Hotfix on top of [#137](https://github.com/psinthorn/iacc-php-mvc/pull/137). Live staging test of #132 v1 produced the green Flex correctly, but the iACC booking detail page showed `BOOKING BY: "LINE bound user #33"` instead of the bound user's actual name.

## Root cause — two issues stacked

### 1. JOIN over-constrained

`LineOA::getBoundUserDetails` joined:

```sql
JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
```

The `a.company_id = u.company_id` constraint is:
- **Redundant** — `bindAgentToUser` already enforces same-tenant at bind time
- **Brittle** — `authorize.company_id` can be NULL for some rows
- **Incompatible with #136** — when bindings are extended to agent-tenant users (different `com_id`), this JOIN would silently exclude them

Dropping the constraint.

### 2. Fallback only catches NULL, not empty string

```php
$bookingByName = $boundUser['authorize_name'] ?? ('LINE bound user #' . $iaccUserId);
```

The `??` operator only treats null as fallback. If an `authorize` row has `name=''` (empty string), the fallback never fires and we'd persist an empty `booking_by`. If `$boundUser` itself is null, `$boundUser['authorize_name']` returns null silently → fallback fires (which is what we saw).

Replaced with a proper priority chain: `name → email → "User #ID"` sentinel. Each level guarded with `!empty()` so empty strings also fall through.

## Bonus

Added `a.phone` to the selected columns in `getBoundUserDetails` — no current call site, but #134 (customer-direct booking) and #136 (extended bindings) will likely use it for booking_by composition.

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container
- 2 files / +21 / −5

## Test plan (staging)

- [ ] Re-deploy from develop
- [ ] Re-send the same `จองทัวร์` template — booking detail now shows your iACC name (e.g. "Sinthorn") in the Booking By field
- [ ] Customer column unchanged (still the customer name from `tour_booking_contacts`)
- [ ] Existing #132 tests should all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
