### PR TITLE
release(v6.3): Agent Booking Capture — LINE OA structured booking

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,37 +668,44 @@ docker exec iacc_php php /var/www/html/tests/test-mvc-comprehensive.php
 
 **#82 — what shipped:** Real-time outbound inventory broadcast. Whenever `tour_allotments` changes via the model layer (create / book / release / set-capacity / close / reopen — 6 hook points), enqueues a `sync_inventory_change` task on the v6.1 task queue. Handler loads the row, resolves the final event type (auto-upgrades `updated` → `depleted` when booked >= total, → `closed` when soft-deleted or `is_closed=1`), and dispatches HMAC-signed POSTs via existing `Webhook::fireEvent()` chain. Event types: `allotment.created` / `allotment.updated` / `allotment.depleted` / `allotment.closed` / `allotment.snapshot`. Admin "Send snapshot" button on the webhooks admin page enqueues backfill events for all active allotments — useful when a partner subscribes mid-month and needs to seed their inventory cache. **Zero new tables, zero migrations** — reuses existing `api_webhooks` + `api_webhook_deliveries`.
 
-### v6.3 — Agent Automation Workers
+### v6.3 — Agent Booking Capture (LINE OA → tour_bookings)
 
-📋 **GitHub:** [milestone v6.3](https://github.com/psinthorn/iacc-php-mvc/milestone/16) — 8 skeleton issues filed
+📋 **GitHub:** [milestone v6.3](https://github.com/psinthorn/iacc-php-mvc/milestone/19) — 3 skeleton issues filed · target Q3 2026
 
-- [#85](https://github.com/psinthorn/iacc-php-mvc/issues/85) Overdue invoice reminders (daily 9am)
-- [#86](https://github.com/psinthorn/iacc-php-mvc/issues/86) Trial expiry notifier (3/1/0 days before expiry)
-- [#87](https://github.com/psinthorn/iacc-php-mvc/issues/87) Auto subscription renewal/suspension
-- [#88](https://github.com/psinthorn/iacc-php-mvc/issues/88) Weekly AR Aging alert to admin
-- [#89](https://github.com/psinthorn/iacc-php-mvc/issues/89) Monthly auto-generated reports (P&L, Revenue) as PDF
-- [#90](https://github.com/psinthorn/iacc-php-mvc/issues/90) Webhook retry worker with exponential backoff
-- [#91](https://github.com/psinthorn/iacc-php-mvc/issues/91) BOT exchange rate updater (daily)
-- [#92](https://github.com/psinthorn/iacc-php-mvc/issues/92) Data cleanup worker (weekly — old task_results, expired sessions, orphaned uploads)
+Sales-agent input flows via LINE OA. Agent-as-user (not customer-as-user) — field reps submit booking data straight from the LINE chat instead of waiting to enter it via the web form back at the office. Three modes, shipping incrementally:
 
-### v6.4 — AI Document Processing (OCR)
+- [#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) **Text-template booking** — structured TH/EN message → parsed → `tour_bookings` row with sales-agent attribution. Ships first (no AI dep, builds the parser harness).
+- [#121](https://github.com/psinthorn/iacc-php-mvc/issues/121) **File-upload booking** — agent attaches CSV/Excel via LINE → preview-and-confirm flow → bulk booking creation. Reuses existing tour-booking CSV import code path.
+- [#122](https://github.com/psinthorn/iacc-php-mvc/issues/122) **Image-OCR booking** — agent snaps voucher photo → vision OCR + LLM field extraction → booking. Hardest; shipped last. Absorbs the old v6.4 "AI Document Processing" directional scope.
 
-📋 **GitHub:** _no milestone yet_ — directional roadmap only. Create milestone before issue tracking.
+> **Roadmap rebalance (2026-05-06):** Original v6.3 was "Agent Automation Workers" (milestone #16, issues #85–#92). Per Option B PM call, customer-facing booking-capture work was prioritized over internal worker automation. Worker automation moved to v6.5 (milestone #16 renamed). BI shifted up from old v6.5 → v6.4. See PR [chore/roadmap-rebalance-v6.3-v6.5] for the README change and milestone audit trail.
 
-- Receipt photo upload → AI extracts vendor, amount, date, category → auto-create expense
-- Invoice email parser → AI parses PDF/image → creates expense or PO draft
-- Contract analyzer → extracts key terms, dates, obligations
-- Thai + English language support for document parsing
+### v6.4 — Conversational BI & Smart Insights
 
-### v6.5 — Conversational BI & Smart Insights
-
-📋 **GitHub:** _no milestone yet_ — directional roadmap only.
+📋 **GitHub:** _no milestone yet_ — directional roadmap only · shifted up from old v6.5 on 2026-05-06
 
 - Chart generation from AI chat ("Show revenue trend this year" → inline Chart.js)
 - Predictive cash flow: AI forecasts 30/60/90 day cash position
 - Transaction anomaly detection (amount outliers, duplicates, missing receipts)
 - Smart automation suggestions based on user behavior patterns
 - Natural language → SQL query execution
+
+### v6.5 — Agent Automation Workers
+
+📋 **GitHub:** [milestone v6.5](https://github.com/psinthorn/iacc-php-mvc/milestone/16) — 8 skeleton issues, all open · target Q1 2027 · _renumbered from old v6.3 on 2026-05-06; same milestone #16, title + labels updated_
+
+Background workers that run while operators sleep — revenue recovery, retention, reliability:
+
+- [#85](https://github.com/psinthorn/iacc-php-mvc/issues/85) Overdue invoice reminders (daily 9am)
+- [#86](https://github.com/psinthorn/iacc-php-mvc/issues/86) Trial expiry notifier (3/1/0 days before expiry)
+- [#87](https://github.com/psinthorn/iacc-php-mvc/issues/87) Auto subscription renewal/suspension
+- [#88](https://github.com/psinthorn/iacc-php-mvc/issues/88) Weekly AR Aging alert to admin
+- [#89](https://github.com/psinthorn/iacc-php-mvc/issues/89) Monthly auto-generated reports (P&L, Revenue) as PDF
+- [#90](https://github.com/psinthorn/iacc-php-mvc/issues/90) Webhook retry worker with exponential backoff — _important: protects v6.2 LINE OA broadcasts_
+- [#91](https://github.com/psinthorn/iacc-php-mvc/issues/91) BOT exchange rate updater (daily)
+- [#92](https://github.com/psinthorn/iacc-php-mvc/issues/92) Data cleanup worker (weekly — old task_results, expired sessions, orphaned uploads)
+
+> **PM recommendation for v6.5 sprint scope:** ship 4 of 8 first — #85, #86, #87 (revenue cluster) + #90 (reliability for v6.2 broadcasts). Defer #88, #89, #91, #92 to v6.5.x or backlog. See conversation log 2026-05-06.
 
 ### v6.6 — Native Sales Channel Connectors
 

--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -245,6 +245,7 @@ return [
     'line_order_detail'  => ['LineOAController', 'orderDetail'],
     'line_messages'      => ['LineOAController', 'messages'],
     'line_users'         => ['LineOAController', 'users'],
+    'line_user_type_update' => ['LineOAController', 'updateUserType'],
     'line_auto_replies'  => ['LineOAController', 'autoReplies'],
     'line_webhook_log'   => ['LineOAController', 'webhookLog'],
     'line_send_message'  => ['LineOAController', 'sendMessagePage'],

--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -248,6 +248,9 @@ return [
     'line_auto_replies'  => ['LineOAController', 'autoReplies'],
     'line_webhook_log'   => ['LineOAController', 'webhookLog'],
     'line_send_message'  => ['LineOAController', 'sendMessagePage'],
+    // v6.3 #120 — agent text-template booking + admin bindings
+    'line_agent_bindings'         => ['LineAgentController', 'bindings'],
+    'line_agent_bind_save'        => ['LineAgentController', 'bindSave'],
     // v6.3 — rich messaging
     'line_probe'                  => ['LineOAController', 'probeConnection'],
     'line_templates'              => ['LineOAController', 'templates'],

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -191,38 +191,81 @@ class LineAgentController extends BaseController
         // Past-date warning prefix for the reply (still write the booking)
         $pastDateWarn = $parser::isDatePast($fields['date']);
 
-        // Compose remark — captures the tour name (line item is added later via web UI) +
-        // any agent notes + agent_code provenance
+        // Resolve the bound user's display name for booking_by (was the
+        // customer name+phone before #132 — semantically wrong).
+        $boundUser = $line->getBoundUserDetails($companyId, $lineUserIdStr);
+        $bookingByName = $boundUser['authorize_name']
+            ?? ('LINE bound user #' . $iaccUserId);
+
+        // Compose remark — captures the tour name + any agent notes +
+        // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id
+        // is deferred to #136 once the bind UI supports agent-tenant users).
         $remarkParts = [];
         $remarkParts[] = '[from LINE agent text]';
         $remarkParts[] = 'Tour: ' . ($tour['name'] ?? '');
-        if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code: ' . $fields['agent_code'];
+        if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code (typed): ' . $fields['agent_code'];
         if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
         $remark = implode("\n", $remarkParts);
 
+        $statusInfo = ['status' => 'draft', 'reason' => 'unresolved'];
         try {
             $tourBookingModel = new \App\Models\TourBooking();
             $bookingNumber = $tourBookingModel->generateBookingNumber($companyId);
+
+            // Allotment-aware status (auto-confirm if seats available)
+            $totalPax = (int)$fields['adults'] + (int)($fields['children'] ?? 0);
+            $statusInfo = $tourBookingModel->resolveBookingStatus(
+                $companyId, $fields['date'], $totalPax
+            );
 
             $bookingData = [
                 'company_id'     => $companyId,
                 'booking_number' => $bookingNumber,
                 'booking_date'   => date('Y-m-d'),
                 'travel_date'    => $fields['date'],
-                'agent_id'       => 0,
+                'agent_id'       => 0, // deferred to #136
                 'sales_rep_id'   => 0,
                 'customer_id'    => 0,
-                'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
+                'booking_by'     => $bookingByName,
                 'pax_adult'      => (int)$fields['adults'],
                 'pax_child'      => (int)($fields['children'] ?? 0),
                 'pax_infant'     => 0,
-                'status'         => 'draft',
+                'pickup_hotel'   => $fields['accommodation'] ?? '',
+                'pickup_room'    => $fields['room'] ?? '',
+                'status'         => $statusInfo['status'],
                 'remark'         => $remark,
-                'created_by'     => $iaccUserId,
+                'created_by'     => $boundUser['authorize_id'] ?? $iaccUserId,
                 'created_via'    => 'line_oa_agent_text',
             ];
 
             $bookingId = $tourBookingModel->createBooking($bookingData);
+
+            // Per-booking customer contact row (proper home for name +
+            // mobile + email + messenger, replacing the "stuff into booking_by"
+            // placeholder from the original #120 PR).
+            if ($bookingId > 0) {
+                $tourBookingModel->saveBookingContact($bookingId, [
+                    'contact_name'       => $fields['customer_name']  ?? '',
+                    'mobile'             => $fields['customer_mobile'] ?? '',
+                    'email'              => $fields['email']          ?? '',
+                    'contact_messengers' => $fields['messenger']      ?? '',
+                ]);
+
+                // Visibility: log a webhook event when status fell to draft
+                // due to allotment so the operator can act on it.
+                if ($statusInfo['status'] === 'draft' && $statusInfo['reason'] !== 'unresolved') {
+                    try {
+                        $line->logWebhookEvent($companyId, 'allotment_blocked', json_encode([
+                            'context'        => 'agent_booking_status_resolved',
+                            'booking_id'     => $bookingId,
+                            'booking_number' => $bookingNumber,
+                            'travel_date'    => $fields['date'],
+                            'pax'            => $totalPax,
+                            'reason'         => $statusInfo['reason'],
+                        ]));
+                    } catch (\Throwable $_) {}
+                }
+            }
         } catch (\Throwable $e) {
             error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
             // Also persist to line_webhook_events so the same error is visible
@@ -255,7 +298,7 @@ class LineAgentController extends BaseController
             'handled'        => true,
             'reason'         => 'booked',
             'booking_id'     => $bookingId,
-            'reply_messages' => [self::buildSuccessFlex($bookingNumber, $tour, $fields, $lang, $pastDateWarn)],
+            'reply_messages' => [self::buildSuccessFlex($bookingNumber, $tour, $fields, $lang, $pastDateWarn, $statusInfo)],
         ];
     }
 
@@ -310,33 +353,70 @@ class LineAgentController extends BaseController
         return ['type' => 'text', 'text' => $text];
     }
 
-    private static function buildSuccessFlex(string $bookingNumber, array $tour, array $fields, string $lang, bool $pastDateWarn): array
+    private static function buildSuccessFlex(string $bookingNumber, array $tour, array $fields, string $lang, bool $pastDateWarn, array $statusInfo = ['status' => 'confirmed', 'reason' => 'available']): array
     {
         $isThai = ($lang === 'th');
-        $title  = $isThai ? '✅ ยืนยันการจอง' : '✅ Booking Confirmed';
+        $confirmed = ($statusInfo['status'] ?? 'confirmed') === 'confirmed';
+
+        if ($confirmed) {
+            $title = $isThai ? '✅ ยืนยันการจอง' : '✅ Booking Confirmed';
+            $titleColor = '#06C755';
+        } else {
+            $title = $isThai ? '⏳ รอการตรวจสอบ' : '⏳ Booking Pending Review';
+            $titleColor = '#e67e22';
+        }
         if ($pastDateWarn) $title .= $isThai ? ' ⚠️ (วันที่ผ่านมาแล้ว)' : ' ⚠️ (past date)';
+
+        // Sub-line explaining why a confirmed booking went to draft.
+        $subLine = '';
+        if (!$confirmed) {
+            $reasonMap = [
+                'no_allotment' => $isThai ? 'ยังไม่มีการตั้งค่าจำนวนที่นั่งสำหรับวันนี้' : 'No allotment configured for this date',
+                'closed'       => $isThai ? 'วันที่นี้ถูกปิดรับการจอง'                  : 'This date is closed for booking',
+                'overbook'     => $isThai ? 'จำนวนที่นั่งไม่เพียงพอ'                    : 'Not enough seats available',
+            ];
+            $subLine = $reasonMap[$statusInfo['reason'] ?? ''] ?? '';
+        }
 
         $paxLine = ($isThai
             ? sprintf('👥 %d ผู้ใหญ่ + %d เด็ก', (int)$fields['adults'], (int)($fields['children'] ?? 0))
             : sprintf('👥 %d adults + %d children', (int)$fields['adults'], (int)($fields['children'] ?? 0)));
 
+        $rows = [
+            ['type' => 'text', 'text' => $title, 'weight' => 'bold', 'size' => 'lg', 'color' => $titleColor, 'wrap' => true],
+            ['type' => 'text', 'text' => $bookingNumber, 'size' => 'sm', 'color' => '#888888', 'margin' => 'sm'],
+        ];
+        if ($subLine !== '') {
+            $rows[] = ['type' => 'text', 'text' => $subLine, 'size' => 'xs', 'color' => '#888888', 'margin' => 'sm', 'wrap' => true];
+        }
+        $rows[] = ['type' => 'separator', 'margin' => 'md'];
+        $rows[] = ['type' => 'text', 'text' => $tour['name'] ?? '', 'weight' => 'bold', 'size' => 'md', 'wrap' => true, 'margin' => 'md'];
+        $rows[] = ['type' => 'text', 'text' => '📅 ' . $fields['date'], 'size' => 'sm', 'margin' => 'sm'];
+        $rows[] = ['type' => 'text', 'text' => $paxLine, 'size' => 'sm', 'margin' => 'sm'];
+        $rows[] = ['type' => 'text', 'text' => '👤 ' . ($fields['customer_name'] ?? ''), 'size' => 'sm', 'margin' => 'sm', 'wrap' => true];
+        $rows[] = ['type' => 'text', 'text' => '📱 ' . ($fields['customer_mobile'] ?? ''), 'size' => 'sm', 'margin' => 'sm'];
+        if (!empty($fields['email'])) {
+            $rows[] = ['type' => 'text', 'text' => '✉️ ' . $fields['email'], 'size' => 'sm', 'margin' => 'sm', 'wrap' => true];
+        }
+        if (!empty($fields['accommodation'])) {
+            $rows[] = ['type' => 'text', 'text' => '🏨 ' . $fields['accommodation'], 'size' => 'sm', 'margin' => 'sm', 'wrap' => true];
+        }
+        if (!empty($fields['room'])) {
+            $rows[] = ['type' => 'text', 'text' => ($isThai ? '🚪 ห้อง ' : '🚪 Room ') . $fields['room'], 'size' => 'sm', 'margin' => 'sm'];
+        }
+
+        $altPrefix = $confirmed
+            ? ($isThai ? 'ยืนยันการจอง '      : 'Booking confirmed ')
+            : ($isThai ? 'การจองรอตรวจสอบ ' : 'Booking pending review ');
+
         return [
             'type' => 'flex',
-            'altText' => ($isThai ? 'ยืนยันการจอง ' : 'Booking confirmed ') . $bookingNumber,
+            'altText' => $altPrefix . $bookingNumber,
             'contents' => [
                 'type' => 'bubble',
                 'body' => [
                     'type' => 'box', 'layout' => 'vertical',
-                    'contents' => [
-                        ['type' => 'text', 'text' => $title, 'weight' => 'bold', 'size' => 'lg', 'color' => '#06C755', 'wrap' => true],
-                        ['type' => 'text', 'text' => $bookingNumber, 'size' => 'sm', 'color' => '#888888', 'margin' => 'sm'],
-                        ['type' => 'separator', 'margin' => 'md'],
-                        ['type' => 'text', 'text' => $tour['name'] ?? '', 'weight' => 'bold', 'size' => 'md', 'wrap' => true, 'margin' => 'md'],
-                        ['type' => 'text', 'text' => '📅 ' . $fields['date'], 'size' => 'sm', 'margin' => 'sm'],
-                        ['type' => 'text', 'text' => $paxLine, 'size' => 'sm', 'margin' => 'sm'],
-                        ['type' => 'text', 'text' => '👤 ' . ($fields['customer_name'] ?? ''), 'size' => 'sm', 'margin' => 'sm', 'wrap' => true],
-                        ['type' => 'text', 'text' => '📞 ' . ($fields['customer_phone'] ?? ''), 'size' => 'sm', 'margin' => 'sm'],
-                    ],
+                    'contents' => $rows,
                 ],
             ],
         ];
@@ -350,8 +430,8 @@ class LineAgentController extends BaseController
             'date_missing'      => $isThai ? 'วันที่ / date'           : 'date / วันที่',
             'date_invalid'      => $isThai ? 'รูปแบบวันที่ (YYYY-MM-DD)' : 'date format (YYYY-MM-DD)',
             'adults_missing'    => $isThai ? 'ผู้ใหญ่ / adults'         : 'adults / ผู้ใหญ่',
-            'customer_missing'  => $isThai ? 'ลูกค้า ชื่อ + เบอร์'       : 'customer name + phone',
-            'agent_code_missing'=> $isThai ? 'ตัวแทน / agent'         : 'agent / ตัวแทน',
+            'customer_missing'  => $isThai ? 'ลูกค้า / customer name'   : 'customer / ลูกค้า',
+            'mobile_missing'    => $isThai ? 'มือถือ / mobile'         : 'mobile / มือถือ',
             'phone_invalid'     => $isThai ? 'เบอร์โทรไม่ถูกต้อง'        : 'phone number invalid',
             'pax_too_few'       => $isThai ? 'จำนวนผู้เดินทางต้อง ≥ 1'   : 'pax must be ≥ 1',
         ];

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -1,0 +1,383 @@
+<?php
+namespace App\Controllers;
+
+/**
+ * LineAgentController — v6.3 #120
+ *
+ * Two responsibilities:
+ *
+ *   1. Web admin UI for binding LINE OA agent accounts to iACC users
+ *      (routes: line_agent_bindings, line_agent_bind_save).
+ *
+ *   2. Webhook ingestion path for bound-agent text messages — invoked
+ *      by line-webhook.php when a text event arrives from a line_user
+ *      with user_type='agent' AND linked_user_id IS NOT NULL.
+ *
+ * The webhook hook is NOT a routed page; it's called as a static-style
+ * service entry. See line-webhook.php near the message-event branch.
+ */
+class LineAgentController extends BaseController
+{
+    private \App\Models\LineOA $lineModel;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->lineModel = new \App\Models\LineOA();
+    }
+
+    // ====================================================================
+    // Admin UI: Agent Bindings page
+    // ====================================================================
+
+    public function bindings(): void
+    {
+        if ((int)($this->user['level'] ?? 0) < 2) {
+            http_response_code(403);
+            die('Admin access required');
+        }
+        $companyId = (int)$this->user['com_id'];
+        $bindings  = $this->lineModel->getAgentBindings($companyId);
+        $iaccUsers = $this->lineModel->getEligibleIaccUsers($companyId);
+        $this->render('line-oa/agent-bindings', [
+            'bindings'  => $bindings,
+            'iaccUsers' => $iaccUsers,
+        ]);
+    }
+
+    public function bindSave(): void
+    {
+        if ((int)($this->user['level'] ?? 0) < 2) {
+            http_response_code(403);
+            die('Admin access required');
+        }
+        $this->verifyCsrf();
+        $companyId    = (int)$this->user['com_id'];
+        $adminId      = (int)($this->user['id'] ?? 0);
+        $lineUserDbId = (int)($_POST['line_user_id'] ?? 0);
+        $action       = $_POST['action'] ?? 'bind';
+
+        if ($lineUserDbId <= 0) {
+            $_SESSION['flash_error'] = 'Missing LINE user.';
+            $this->redirect('line_agent_bindings');
+            return;
+        }
+
+        if ($action === 'unbind') {
+            $this->lineModel->unbindAgent($companyId, $lineUserDbId);
+            $_SESSION['flash_success'] = 'Agent binding removed.';
+            $this->redirect('line_agent_bindings');
+            return;
+        }
+
+        // bind
+        $iaccUserId = (int)($_POST['iacc_user_id'] ?? 0);
+        if ($iaccUserId <= 0) {
+            $_SESSION['flash_error'] = 'Pick an iACC user to bind.';
+            $this->redirect('line_agent_bindings');
+            return;
+        }
+
+        $ok = $this->lineModel->bindAgentToUser($companyId, $lineUserDbId, $iaccUserId, $adminId);
+        if ($ok) {
+            $_SESSION['flash_success'] = 'Agent bound successfully.';
+        } else {
+            $_SESSION['flash_error'] = 'Could not bind — verify the LINE user is type=agent and the iACC user belongs to this company.';
+        }
+        $this->redirect('line_agent_bindings');
+    }
+
+    // ====================================================================
+    // CSRF helper (mirrors LineOAController)
+    // ====================================================================
+
+    protected function verifyCsrf(): void
+    {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') return;
+        $token = $_POST['csrf_token'] ?? '';
+        if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+            http_response_code(403);
+            die('CSRF token mismatch');
+        }
+    }
+
+    // ====================================================================
+    // Webhook path: ingestText
+    // ====================================================================
+
+    /**
+     * Called from line-webhook.php when a text message arrives from a
+     * bound agent. Returns:
+     *
+     *   ['handled' => bool, 'reason' => string, 'booking_id' => int|null,
+     *    'reply_messages' => array]   // ready-to-send LINE Messaging API payload
+     *
+     * Caller is responsible for taking $result['reply_messages'] and
+     * pushing them via LineService::replyMessage($replyToken, …).
+     *
+     * 'handled' is false when the message has no booking trigger — caller
+     * should fall through to existing auto-reply matching.
+     */
+    public static function ingestText(int $companyId, string $messageText, string $lineUserIdStr): array
+    {
+        $parser = \App\Models\AgentBookingParser::class;
+        $parsed = $parser::parse($messageText);
+
+        // No trigger phrase => not a booking message; let auto-reply handle it
+        if (!empty($parsed['errors']) && in_array('no_trigger', $parsed['errors'], true)) {
+            return ['handled' => false, 'reason' => 'no_trigger', 'booking_id' => null, 'reply_messages' => []];
+        }
+
+        $lang = $parsed['lang'];
+
+        // Validation errors => reply with a missing-fields card
+        if (!$parsed['ok']) {
+            return [
+                'handled'        => true,
+                'reason'         => 'validation_failed',
+                'booking_id'     => null,
+                'reply_messages' => [self::buildErrorFlex($parsed['errors'], $lang)],
+            ];
+        }
+
+        $fields = $parsed['fields'];
+
+        // Resolve the bound iACC user
+        $line = new \App\Models\LineOA();
+        $iaccUserId = $line->getBoundIaccUserId($companyId, $lineUserIdStr);
+        if (!$iaccUserId) {
+            return [
+                'handled'        => true,
+                'reason'         => 'not_bound',
+                'booking_id'     => null,
+                'reply_messages' => [self::buildPlainText($lang === 'th'
+                    ? 'คุณยังไม่ได้รับการผูกบัญชีเป็นตัวแทน กรุณาติดต่อผู้ดูแลระบบ'
+                    : 'Your LINE account is not bound as an agent. Please contact your admin.')],
+            ];
+        }
+
+        // Match the tour name within the tenant's tours
+        $tourMatch = self::matchTour($companyId, $fields['tour_name']);
+        if ($tourMatch['status'] === 'none') {
+            return [
+                'handled'        => true,
+                'reason'         => 'tour_not_found',
+                'booking_id'     => null,
+                'reply_messages' => [self::buildPlainText(($lang === 'th'
+                    ? 'ไม่พบทัวร์ที่ตรงกับ "%s" ในระบบ'
+                    : 'No tour matching "%s" found in your system.'),
+                    [$fields['tour_name']])],
+            ];
+        }
+        if ($tourMatch['status'] === 'multiple') {
+            $list = '';
+            foreach ($tourMatch['candidates'] as $i => $c) {
+                $list .= ($i + 1) . ') ' . $c['name'] . "\n";
+            }
+            return [
+                'handled'        => true,
+                'reason'         => 'tour_ambiguous',
+                'booking_id'     => null,
+                'reply_messages' => [self::buildPlainText(($lang === 'th'
+                    ? "พบทัวร์หลายรายการที่ตรงกัน:\n%sกรุณาส่งใหม่พร้อมระบุชื่อให้ชัดเจนยิ่งขึ้น"
+                    : "Multiple tours matched:\n%sPlease re-send with a more specific name."),
+                    [$list])],
+            ];
+        }
+
+        // Single tour match — build booking row
+        $tour = $tourMatch['tour'];
+
+        // Past-date warning prefix for the reply (still write the booking)
+        $pastDateWarn = $parser::isDatePast($fields['date']);
+
+        $bookingNumber = self::generateBookingNumber($companyId);
+
+        // Compose remark — captures the tour name (line item is added later via web UI) +
+        // any agent notes + agent_code provenance
+        $remarkParts = [];
+        $remarkParts[] = '[from LINE agent text]';
+        $remarkParts[] = 'Tour: ' . ($tour['name'] ?? '');
+        if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code: ' . $fields['agent_code'];
+        if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
+        $remark = implode("\n", $remarkParts);
+
+        $bookingData = [
+            'company_id'     => $companyId,
+            'booking_number' => $bookingNumber,
+            'booking_date'   => date('Y-m-d'),
+            'travel_date'    => $fields['date'],
+            'agent_id'       => 0,
+            'sales_rep_id'   => 0,
+            'customer_id'    => 0,
+            'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
+            'pax_adult'      => (int)$fields['adults'],
+            'pax_child'      => (int)($fields['children'] ?? 0),
+            'pax_infant'     => 0,
+            'status'         => 'pending',
+            'remark'         => $remark,
+            'created_by'     => $iaccUserId,
+            'created_via'    => 'line_oa_agent_text',
+        ];
+
+        try {
+            $tourBookingModel = new \App\Models\TourBooking();
+            $bookingId = $tourBookingModel->createBooking($bookingData);
+        } catch (\Throwable $e) {
+            error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
+            $bookingId = 0;
+        }
+
+        if ($bookingId <= 0) {
+            return [
+                'handled'        => true,
+                'reason'         => 'write_failed',
+                'booking_id'     => null,
+                'reply_messages' => [self::buildPlainText($lang === 'th'
+                    ? 'เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ'
+                    : 'Could not save the booking. Please contact your admin.')],
+            ];
+        }
+
+        return [
+            'handled'        => true,
+            'reason'         => 'booked',
+            'booking_id'     => $bookingId,
+            'reply_messages' => [self::buildSuccessFlex($bookingNumber, $tour, $fields, $lang, $pastDateWarn)],
+        ];
+    }
+
+    // ====================================================================
+    // Helpers — tour match, booking insert, reply builders
+    // ====================================================================
+
+    /**
+     * Fuzzy match a tour name against the company's `tour_products`.
+     * Returns ['status' => 'none'|'one'|'multiple', 'tour' => array|null, 'candidates' => array]
+     */
+    private static function matchTour(int $companyId, string $needle): array
+    {
+        global $db;
+        $needle = trim($needle);
+        if ($needle === '') return ['status' => 'none', 'tour' => null, 'candidates' => []];
+
+        $stmt = $db->conn->prepare(
+            "SELECT id, tour_name AS name
+             FROM tour_products
+             WHERE company_id = ?
+               AND deleted_at IS NULL
+               AND (tour_name LIKE CONCAT('%', ?, '%')
+                    OR ? LIKE CONCAT('%', tour_name, '%'))
+             ORDER BY CHAR_LENGTH(tour_name) ASC
+             LIMIT 5"
+        );
+        $stmt->bind_param('iss', $companyId, $needle, $needle);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+
+        if (empty($rows))    return ['status' => 'none',     'tour' => null,    'candidates' => []];
+        if (count($rows) === 1) return ['status' => 'one',  'tour' => $rows[0],'candidates' => $rows];
+        return ['status' => 'multiple', 'tour' => null, 'candidates' => $rows];
+    }
+
+    private static function generateBookingNumber(int $companyId): string
+    {
+        // Mirrors existing convention: TB-YYYYMMDD-NNN per company per day
+        global $db;
+        $today = date('Ymd');
+        $prefix = 'TB-' . $today . '-';
+
+        $stmt = $db->conn->prepare(
+            "SELECT COUNT(*) AS cnt FROM tour_bookings
+             WHERE company_id = ? AND booking_number LIKE ?"
+        );
+        $like = $prefix . '%';
+        $stmt->bind_param('is', $companyId, $like);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        $next = ((int)($row['cnt'] ?? 0)) + 1;
+        return $prefix . str_pad((string)$next, 3, '0', STR_PAD_LEFT);
+    }
+
+    // ----- Flex / text reply builders -----
+
+    private static function buildPlainText(string $template, array $vars = []): array
+    {
+        $text = $vars ? vsprintf($template, $vars) : $template;
+        return ['type' => 'text', 'text' => $text];
+    }
+
+    private static function buildSuccessFlex(string $bookingNumber, array $tour, array $fields, string $lang, bool $pastDateWarn): array
+    {
+        $isThai = ($lang === 'th');
+        $title  = $isThai ? '✅ ยืนยันการจอง' : '✅ Booking Confirmed';
+        if ($pastDateWarn) $title .= $isThai ? ' ⚠️ (วันที่ผ่านมาแล้ว)' : ' ⚠️ (past date)';
+
+        $paxLine = ($isThai
+            ? sprintf('👥 %d ผู้ใหญ่ + %d เด็ก', (int)$fields['adults'], (int)($fields['children'] ?? 0))
+            : sprintf('👥 %d adults + %d children', (int)$fields['adults'], (int)($fields['children'] ?? 0)));
+
+        return [
+            'type' => 'flex',
+            'altText' => ($isThai ? 'ยืนยันการจอง ' : 'Booking confirmed ') . $bookingNumber,
+            'contents' => [
+                'type' => 'bubble',
+                'body' => [
+                    'type' => 'box', 'layout' => 'vertical',
+                    'contents' => [
+                        ['type' => 'text', 'text' => $title, 'weight' => 'bold', 'size' => 'lg', 'color' => '#06C755', 'wrap' => true],
+                        ['type' => 'text', 'text' => $bookingNumber, 'size' => 'sm', 'color' => '#888888', 'margin' => 'sm'],
+                        ['type' => 'separator', 'margin' => 'md'],
+                        ['type' => 'text', 'text' => $tour['name'] ?? '', 'weight' => 'bold', 'size' => 'md', 'wrap' => true, 'margin' => 'md'],
+                        ['type' => 'text', 'text' => '📅 ' . $fields['date'], 'size' => 'sm', 'margin' => 'sm'],
+                        ['type' => 'text', 'text' => $paxLine, 'size' => 'sm', 'margin' => 'sm'],
+                        ['type' => 'text', 'text' => '👤 ' . ($fields['customer_name'] ?? ''), 'size' => 'sm', 'margin' => 'sm', 'wrap' => true],
+                        ['type' => 'text', 'text' => '📞 ' . ($fields['customer_phone'] ?? ''), 'size' => 'sm', 'margin' => 'sm'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private static function buildErrorFlex(array $errors, string $lang): array
+    {
+        $isThai = ($lang === 'th');
+        $labelMap = [
+            'tour_name_missing' => $isThai ? 'ทัวร์ / tour'           : 'tour / ทัวร์',
+            'date_missing'      => $isThai ? 'วันที่ / date'           : 'date / วันที่',
+            'date_invalid'      => $isThai ? 'รูปแบบวันที่ (YYYY-MM-DD)' : 'date format (YYYY-MM-DD)',
+            'adults_missing'    => $isThai ? 'ผู้ใหญ่ / adults'         : 'adults / ผู้ใหญ่',
+            'customer_missing'  => $isThai ? 'ลูกค้า ชื่อ + เบอร์'       : 'customer name + phone',
+            'agent_code_missing'=> $isThai ? 'ตัวแทน / agent'         : 'agent / ตัวแทน',
+            'phone_invalid'     => $isThai ? 'เบอร์โทรไม่ถูกต้อง'        : 'phone number invalid',
+            'pax_too_few'       => $isThai ? 'จำนวนผู้เดินทางต้อง ≥ 1'   : 'pax must be ≥ 1',
+        ];
+
+        $bullets = [];
+        foreach ($errors as $err) {
+            $label = $labelMap[$err] ?? $err;
+            $bullets[] = ['type' => 'text', 'text' => '• ' . $label, 'size' => 'sm', 'wrap' => true, 'margin' => 'sm'];
+        }
+
+        return [
+            'type' => 'flex',
+            'altText' => ($isThai ? 'การจองไม่ครบถ้วน' : 'Booking incomplete'),
+            'contents' => [
+                'type' => 'bubble',
+                'body' => [
+                    'type' => 'box', 'layout' => 'vertical',
+                    'contents' => array_merge([
+                        ['type' => 'text', 'text' => ($isThai ? '⚠️ การจองไม่ครบถ้วน' : '⚠️ Booking Incomplete'), 'weight' => 'bold', 'size' => 'lg', 'color' => '#e67e22'],
+                        ['type' => 'separator', 'margin' => 'md'],
+                        ['type' => 'text', 'text' => ($isThai ? 'กรุณาเพิ่ม:' : 'Please add:'), 'size' => 'sm', 'margin' => 'md', 'weight' => 'bold'],
+                    ], $bullets, [
+                        ['type' => 'text', 'text' => ($isThai ? 'แล้วส่งข้อความใหม่อีกครั้ง' : 'Then re-send the full template.'), 'size' => 'xs', 'color' => '#888888', 'margin' => 'lg', 'wrap' => true],
+                    ]),
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -216,7 +216,7 @@ class LineAgentController extends BaseController
                 'pax_adult'      => (int)$fields['adults'],
                 'pax_child'      => (int)($fields['children'] ?? 0),
                 'pax_infant'     => 0,
-                'status'         => 'pending',
+                'status'         => 'draft',
                 'remark'         => $remark,
                 'created_by'     => $iaccUserId,
                 'created_via'    => 'line_oa_agent_text',
@@ -225,6 +225,17 @@ class LineAgentController extends BaseController
             $bookingId = $tourBookingModel->createBooking($bookingData);
         } catch (\Throwable $e) {
             error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
+            // Also persist to line_webhook_events so the same error is visible
+            // via SQL on cPanel without having to read PHP error logs.
+            try {
+                $line->logWebhookEvent($companyId, 'error', json_encode([
+                    'context' => 'agent_booking_write',
+                    'error'   => $e->getMessage(),
+                    'fields'  => $fields ?? [],
+                ]));
+            } catch (\Throwable $_) {
+                // logging is best-effort; never let it mask the original error
+            }
             $bookingId = 0;
             $bookingNumber = '';
         }

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -191,8 +191,6 @@ class LineAgentController extends BaseController
         // Past-date warning prefix for the reply (still write the booking)
         $pastDateWarn = $parser::isDatePast($fields['date']);
 
-        $bookingNumber = self::generateBookingNumber($companyId);
-
         // Compose remark — captures the tour name (line item is added later via web UI) +
         // any agent notes + agent_code provenance
         $remarkParts = [];
@@ -202,30 +200,33 @@ class LineAgentController extends BaseController
         if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
         $remark = implode("\n", $remarkParts);
 
-        $bookingData = [
-            'company_id'     => $companyId,
-            'booking_number' => $bookingNumber,
-            'booking_date'   => date('Y-m-d'),
-            'travel_date'    => $fields['date'],
-            'agent_id'       => 0,
-            'sales_rep_id'   => 0,
-            'customer_id'    => 0,
-            'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
-            'pax_adult'      => (int)$fields['adults'],
-            'pax_child'      => (int)($fields['children'] ?? 0),
-            'pax_infant'     => 0,
-            'status'         => 'pending',
-            'remark'         => $remark,
-            'created_by'     => $iaccUserId,
-            'created_via'    => 'line_oa_agent_text',
-        ];
-
         try {
             $tourBookingModel = new \App\Models\TourBooking();
+            $bookingNumber = $tourBookingModel->generateBookingNumber($companyId);
+
+            $bookingData = [
+                'company_id'     => $companyId,
+                'booking_number' => $bookingNumber,
+                'booking_date'   => date('Y-m-d'),
+                'travel_date'    => $fields['date'],
+                'agent_id'       => 0,
+                'sales_rep_id'   => 0,
+                'customer_id'    => 0,
+                'booking_by'     => trim(($fields['customer_name'] ?? '') . ' ' . ($fields['customer_phone'] ?? '')),
+                'pax_adult'      => (int)$fields['adults'],
+                'pax_child'      => (int)($fields['children'] ?? 0),
+                'pax_infant'     => 0,
+                'status'         => 'pending',
+                'remark'         => $remark,
+                'created_by'     => $iaccUserId,
+                'created_via'    => 'line_oa_agent_text',
+            ];
+
             $bookingId = $tourBookingModel->createBooking($bookingData);
         } catch (\Throwable $e) {
             error_log('LineAgentController::ingestText createBooking failed: ' . $e->getMessage());
             $bookingId = 0;
+            $bookingNumber = '';
         }
 
         if ($bookingId <= 0) {
@@ -288,27 +289,6 @@ class LineAgentController extends BaseController
         if (empty($rows))    return ['status' => 'none',     'tour' => null,    'candidates' => []];
         if (count($rows) === 1) return ['status' => 'one',  'tour' => $rows[0],'candidates' => $rows];
         return ['status' => 'multiple', 'tour' => null, 'candidates' => $rows];
-    }
-
-    private static function generateBookingNumber(int $companyId): string
-    {
-        // Mirrors existing convention: TB-YYYYMMDD-NNN per company per day
-        global $db;
-        $today = date('Ymd');
-        $prefix = 'TB-' . $today . '-';
-
-        $stmt = $db->conn->prepare(
-            "SELECT COUNT(*) AS cnt FROM tour_bookings
-             WHERE company_id = ? AND booking_number LIKE ?"
-        );
-        $like = $prefix . '%';
-        $stmt->bind_param('is', $companyId, $like);
-        $stmt->execute();
-        $row = $stmt->get_result()->fetch_assoc();
-        $stmt->close();
-
-        $next = ((int)($row['cnt'] ?? 0)) + 1;
-        return $prefix . str_pad((string)$next, 3, '0', STR_PAD_LEFT);
     }
 
     // ----- Flex / text reply builders -----

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -262,6 +262,11 @@ class LineAgentController extends BaseController
         $needle = trim($needle);
         if ($needle === '') return ['status' => 'none', 'tour' => null, 'candidates' => []];
 
+        // CONVERT + COLLATE on each bound parameter pins the LIKE comparison to
+        // utf8mb4_unicode_ci regardless of the server's `collation_connection`.
+        // Without this, MySQL throws "Illegal mix of collations" when the
+        // connection collation (e.g. utf8mb4_bin on staging) differs from the
+        // column collation (utf8mb4_unicode_ci).
         $stmt = $db->conn->prepare(
             "SELECT m.id, m.model_name AS name
              FROM model m
@@ -269,9 +274,9 @@ class LineAgentController extends BaseController
              WHERE m.company_id = ?
                AND m.deleted_at IS NULL
                AND m.is_active = 1
-               AND (m.model_name LIKE CONCAT('%', ?, '%')
-                    OR ? LIKE CONCAT('%', m.model_name, '%')
-                    OR t.name LIKE CONCAT('%', ?, '%'))
+               AND (m.model_name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%')
+                    OR CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', m.model_name, '%')
+                    OR t.name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%'))
              ORDER BY CHAR_LENGTH(m.model_name) ASC
              LIMIT 5"
         );

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -252,7 +252,8 @@ class LineAgentController extends BaseController
     // ====================================================================
 
     /**
-     * Fuzzy match a tour name against the company's `tour_products`.
+     * Fuzzy match a tour name against the company's `model` table
+     * (joined with `type` so agents can match by category name too).
      * Returns ['status' => 'none'|'one'|'multiple', 'tour' => array|null, 'candidates' => array]
      */
     private static function matchTour(int $companyId, string $needle): array
@@ -262,16 +263,19 @@ class LineAgentController extends BaseController
         if ($needle === '') return ['status' => 'none', 'tour' => null, 'candidates' => []];
 
         $stmt = $db->conn->prepare(
-            "SELECT id, tour_name AS name
-             FROM tour_products
-             WHERE company_id = ?
-               AND deleted_at IS NULL
-               AND (tour_name LIKE CONCAT('%', ?, '%')
-                    OR ? LIKE CONCAT('%', tour_name, '%'))
-             ORDER BY CHAR_LENGTH(tour_name) ASC
+            "SELECT m.id, m.model_name AS name
+             FROM model m
+             LEFT JOIN type t ON m.type_id = t.id
+             WHERE m.company_id = ?
+               AND m.deleted_at IS NULL
+               AND m.is_active = 1
+               AND (m.model_name LIKE CONCAT('%', ?, '%')
+                    OR ? LIKE CONCAT('%', m.model_name, '%')
+                    OR t.name LIKE CONCAT('%', ?, '%'))
+             ORDER BY CHAR_LENGTH(m.model_name) ASC
              LIMIT 5"
         );
-        $stmt->bind_param('iss', $companyId, $needle, $needle);
+        $stmt->bind_param('isss', $companyId, $needle, $needle, $needle);
         $stmt->execute();
         $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
         $stmt->close();

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -193,9 +193,21 @@ class LineAgentController extends BaseController
 
         // Resolve the bound user's display name for booking_by (was the
         // customer name+phone before #132 — semantically wrong).
+        // Priority: name → email → bare "User #ID" sentinel. Empty strings
+        // (not just nulls) also fall through, since some authorize rows have
+        // name='' rather than NULL.
         $boundUser = $line->getBoundUserDetails($companyId, $lineUserIdStr);
-        $bookingByName = $boundUser['authorize_name']
-            ?? ('LINE bound user #' . $iaccUserId);
+        $bookingByName = '';
+        if ($boundUser) {
+            if (!empty($boundUser['authorize_name'])) {
+                $bookingByName = $boundUser['authorize_name'];
+            } elseif (!empty($boundUser['email'])) {
+                $bookingByName = $boundUser['email'];
+            }
+        }
+        if ($bookingByName === '') {
+            $bookingByName = 'User #' . $iaccUserId;
+        }
 
         // Compose remark — captures the tour name + any agent notes +
         // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id

--- a/app/Controllers/LineOAController.php
+++ b/app/Controllers/LineOAController.php
@@ -649,6 +649,33 @@ class LineOAController extends BaseController
     }
 
     /**
+     * v6.3 #120 — Update a LINE user's user_type from the Users page dropdown.
+     * Required so admins can promote a user to 'agent' before binding.
+     */
+    public function updateUserType(): void
+    {
+        if ((int)($this->user['level'] ?? 0) < 2) {
+            http_response_code(403);
+            die('Admin access required');
+        }
+        $this->verifyCsrf();
+        $companyId    = (int)$this->user['com_id'];
+        $lineUserDbId = (int)($_POST['line_user_id'] ?? 0);
+        $userType     = $_POST['user_type'] ?? '';
+
+        if ($lineUserDbId <= 0) {
+            $_SESSION['flash_error'] = 'Missing LINE user.';
+        } elseif (!in_array($userType, ['customer', 'agent'], true)) {
+            $_SESSION['flash_error'] = 'Invalid user type.';
+        } elseif ($this->lineModel->updateUserType($companyId, $lineUserDbId, $userType)) {
+            $_SESSION['flash_success'] = 'User type updated.';
+        } else {
+            $_SESSION['flash_error'] = 'Could not update — verify the user belongs to this company.';
+        }
+        $this->redirect('line_users');
+    }
+
+    /**
      * Auto-reply rules management
      */
     public function autoReplies(): void

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -1,0 +1,267 @@
+<?php
+namespace App\Models;
+
+/**
+ * AgentBookingParser — v6.3 #120
+ *
+ * Stateless parser that converts an inbound LINE OA text message from a
+ * sales agent into a structured booking record (or a list of validation
+ * errors).
+ *
+ * Locked schema (PM call 2026-05-06, see issue #120):
+ *
+ *   จองทัวร์    OR    book tour
+ *   ทัวร์: <tour_name>           |   tour: <tour_name>
+ *   วันที่: <YYYY-MM-DD>         |   date: <YYYY-MM-DD>
+ *   ผู้ใหญ่: <int>               |   adults: <int>
+ *   เด็ก: <int>                  |   children: <int>
+ *   ลูกค้า: <name> <phone>       |   customer: <name> <phone>
+ *   ตัวแทน: <agent_code>         |   agent: <agent_code>
+ *   หมายเหตุ: <free text>         |   notes: <free text>
+ *
+ * Required: tour, date, adults, customer, agent.
+ * Optional: children, notes.
+ *
+ * Usage:
+ *   $result = AgentBookingParser::parse($messageText);
+ *   if ($result['ok']) {
+ *       $fields = $result['fields'];   // ['tour_name'=>..., 'date'=>..., 'adults'=>4, ...]
+ *       $lang   = $result['lang'];     // 'th' | 'en'
+ *   } else {
+ *       $errors = $result['errors'];   // ['date_missing', 'phone_invalid', ...]
+ *       $lang   = $result['lang'];
+ *   }
+ */
+class AgentBookingParser
+{
+    // Trigger phrases (any one anywhere in the message activates parsing)
+    private const TRIGGERS = [
+        'th' => ['จองทัวร์'],
+        'en' => ['book tour'],
+    ];
+
+    // Field-keyword aliases (TH and EN); first match wins per language
+    private const FIELD_KEYWORDS = [
+        'tour_name'      => ['ทัวร์', 'tour'],
+        'date'           => ['วันที่', 'date'],
+        'adults'         => ['ผู้ใหญ่', 'adults'],
+        'children'       => ['เด็ก', 'children'],
+        'customer'       => ['ลูกค้า', 'customer'],
+        'agent_code'     => ['ตัวแทน', 'agent'],
+        'notes'          => ['หมายเหตุ', 'notes'],
+    ];
+
+    private const REQUIRED_FIELDS = ['tour_name', 'date', 'adults', 'customer', 'agent_code'];
+
+    /**
+     * Returns:
+     *   ['ok' => bool, 'fields' => array, 'errors' => string[], 'lang' => 'th'|'en', 'matched_trigger' => string|null]
+     *
+     * 'ok' is true only when no validation errors are present.
+     */
+    public static function parse(string $message): array
+    {
+        $message = self::convertThaiNumerals($message);
+        $lang    = self::detectLang($message);
+        $trigger = self::detectTrigger($message);
+
+        if ($trigger === null) {
+            return [
+                'ok'              => false,
+                'fields'          => [],
+                'errors'          => ['no_trigger'],
+                'lang'            => $lang,
+                'matched_trigger' => null,
+            ];
+        }
+
+        $fields = self::extractFields($message);
+        $errors = self::validate($fields);
+
+        return [
+            'ok'              => empty($errors),
+            'fields'          => $fields,
+            'errors'          => $errors,
+            'lang'            => $lang,
+            'matched_trigger' => $trigger,
+        ];
+    }
+
+    // ============================================================
+    // Lang + trigger detection
+    // ============================================================
+
+    private static function detectLang(string $message): string
+    {
+        // Heuristic: any Thai char => TH; else EN
+        return preg_match('/[\x{0E00}-\x{0E7F}]/u', $message) ? 'th' : 'en';
+    }
+
+    private static function detectTrigger(string $message): ?string
+    {
+        $haystack = mb_strtolower($message);
+        foreach (self::TRIGGERS as $lang => $phrases) {
+            foreach ($phrases as $p) {
+                if (mb_stripos($haystack, $p) !== false) return $p;
+            }
+        }
+        return null;
+    }
+
+    // ============================================================
+    // Field extraction
+    // ============================================================
+
+    /**
+     * Extract structured fields by anchoring on keyword + ":" and reading until
+     * the next keyword anchor or end-of-string. Order-independent.
+     */
+    private static function extractFields(string $message): array
+    {
+        // Build a sorted regex of all keyword anchors so we can split on them.
+        $anchors = [];
+        foreach (self::FIELD_KEYWORDS as $field => $keywords) {
+            foreach ($keywords as $kw) {
+                $anchors[] = preg_quote($kw, '/');
+            }
+        }
+        // Sort longest-first so e.g. "agent" doesn't accidentally match inside "agentcode"
+        usort($anchors, fn($a, $b) => mb_strlen($b) - mb_strlen($a));
+        $anchorRe = '(?:' . implode('|', $anchors) . ')';
+
+        // Find every "<keyword>:<value>" segment, value runs until next keyword or EOL/EOS
+        $fields = [];
+        $pattern = '/(' . $anchorRe . ')\s*[:：]\s*(.*?)(?=(?:\s+(?:' . $anchorRe . ')\s*[:：])|$)/sui';
+        if (preg_match_all($pattern, $message, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $m) {
+                $kw  = trim($m[1]);
+                $val = trim($m[2]);
+                $field = self::keywordToField($kw);
+                if ($field !== null && !isset($fields[$field])) {
+                    $fields[$field] = $val;
+                }
+            }
+        }
+
+        // Normalize field types
+        if (isset($fields['adults']))   $fields['adults']   = self::toIntOrNull($fields['adults']);
+        if (isset($fields['children'])) $fields['children'] = self::toIntOrNull($fields['children']);
+        // Default children=0 if not provided (optional field)
+        $fields['children'] = $fields['children'] ?? 0;
+
+        // Customer field is "<name> <phone>" — split on last whitespace before
+        // a phone-like token so names with spaces work.
+        if (isset($fields['customer'])) {
+            $split = self::splitCustomer($fields['customer']);
+            $fields['customer_name']  = $split['name'];
+            $fields['customer_phone'] = $split['phone'];
+        }
+
+        return $fields;
+    }
+
+    private static function keywordToField(string $keyword): ?string
+    {
+        $kw = mb_strtolower(trim($keyword));
+        foreach (self::FIELD_KEYWORDS as $field => $keywords) {
+            foreach ($keywords as $k) {
+                if (mb_strtolower($k) === $kw) return $field;
+            }
+        }
+        return null;
+    }
+
+    private static function splitCustomer(string $raw): array
+    {
+        // Find a phone-like token (8+ digits with optional dashes / leading +)
+        if (preg_match('/(\+?\d[\d\-\s]{7,})\s*$/', $raw, $m)) {
+            $phone = preg_replace('/[\s\-]/', '', $m[1]);
+            $name  = trim(str_replace($m[1], '', $raw));
+            return ['name' => $name, 'phone' => $phone];
+        }
+        // No phone detected — whole string is the name
+        return ['name' => trim($raw), 'phone' => ''];
+    }
+
+    private static function toIntOrNull(string $v): ?int
+    {
+        $v = trim($v);
+        if ($v === '' || !preg_match('/^\d+$/', $v)) return null;
+        return (int)$v;
+    }
+
+    /**
+     * Convert Thai numerals (๐-๙) to Arabic numerals.
+     */
+    private static function convertThaiNumerals(string $s): string
+    {
+        return strtr($s, [
+            '๐' => '0', '๑' => '1', '๒' => '2', '๓' => '3', '๔' => '4',
+            '๕' => '5', '๖' => '6', '๗' => '7', '๘' => '8', '๙' => '9',
+        ]);
+    }
+
+    // ============================================================
+    // Validation
+    // ============================================================
+
+    private static function validate(array $f): array
+    {
+        $errors = [];
+
+        foreach (self::REQUIRED_FIELDS as $req) {
+            if ($req === 'customer') {
+                if (empty($f['customer_name']) || empty($f['customer_phone'])) {
+                    $errors[] = 'customer_missing';
+                }
+                continue;
+            }
+            if (!isset($f[$req]) || $f[$req] === '' || $f[$req] === null) {
+                $errors[] = $req . '_missing';
+            }
+        }
+
+        if (isset($f['date']) && $f['date'] !== '') {
+            if (!self::isValidDate($f['date'])) {
+                $errors[] = 'date_invalid';
+            }
+        }
+
+        if (isset($f['adults']) && $f['adults'] !== null) {
+            $totalPax = (int)$f['adults'] + (int)($f['children'] ?? 0);
+            if ($totalPax < 1) $errors[] = 'pax_too_few';
+        }
+
+        if (!empty($f['customer_phone']) && !self::isValidPhone($f['customer_phone'])) {
+            $errors[] = 'phone_invalid';
+        }
+
+        return $errors;
+    }
+
+    private static function isValidDate(string $date): bool
+    {
+        // Accept YYYY-MM-DD only (locked schema)
+        if (!preg_match('/^\d{4}-\d{1,2}-\d{1,2}$/', $date)) return false;
+        $ts = strtotime($date);
+        return $ts !== false;
+    }
+
+    private static function isValidPhone(string $phone): bool
+    {
+        // Strip and check digit count: 9–13 digits (covers TH mobile + intl)
+        $digits = preg_replace('/\D/', '', $phone);
+        return strlen($digits) >= 9 && strlen($digits) <= 13;
+    }
+
+    /**
+     * Helper for callers: was this date in the past relative to today?
+     * (Not a validation error — just used to add a warning to the reply.)
+     */
+    public static function isDatePast(string $date): bool
+    {
+        $ts = strtotime($date);
+        if ($ts === false) return false;
+        return $ts < strtotime('today');
+    }
+}

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -34,10 +34,23 @@ namespace App\Models;
  */
 class AgentBookingParser
 {
-    // Trigger phrases (any one anywhere in the message activates parsing)
-    private const TRIGGERS = [
+    // Trigger phrases (case-insensitive substring match anywhere in the message).
+    //
+    // Strong triggers always activate the agent intercept — useful so an empty
+    // template still gets the validation Flex listing the missing fields.
+    //
+    // Weak triggers only activate when the message also contains at least one
+    // structured field anchor (ทัวร์:, date:, etc.). Otherwise we let the
+    // legacy "book/จอง <date> <time>" customer handler in line-webhook.php
+    // keep handling them — that flow is for non-agent customers and is
+    // unrelated to agent text-template booking.
+    private const TRIGGERS_STRONG = [
         'th' => ['จองทัวร์'],
         'en' => ['book tour'],
+    ];
+    private const TRIGGERS_WEAK = [
+        'th' => ['จอง'],
+        'en' => ['book'],
     ];
 
     // Field-keyword aliases (TH and EN); first match wins per language
@@ -65,7 +78,10 @@ class AgentBookingParser
         $lang    = self::detectLang($message);
         $trigger = self::detectTrigger($message);
 
-        if ($trigger === null) {
+        // No trigger at all, OR a weak trigger with no field anchor — let
+        // the legacy customer-date handler keep handling the message.
+        if ($trigger === null
+            || (!$trigger['strong'] && !self::hasAnyAnchor($message))) {
             return [
                 'ok'              => false,
                 'fields'          => [],
@@ -83,7 +99,7 @@ class AgentBookingParser
             'fields'          => $fields,
             'errors'          => $errors,
             'lang'            => $lang,
-            'matched_trigger' => $trigger,
+            'matched_trigger' => $trigger['phrase'],
         ];
     }
 
@@ -97,15 +113,46 @@ class AgentBookingParser
         return preg_match('/[\x{0E00}-\x{0E7F}]/u', $message) ? 'th' : 'en';
     }
 
-    private static function detectTrigger(string $message): ?string
+    /**
+     * Returns ['phrase' => string, 'strong' => bool] or null if no trigger
+     * is found. Strong triggers are unconditional; weak triggers must be
+     * paired with a field anchor (see hasAnyAnchor) to count.
+     */
+    private static function detectTrigger(string $message): ?array
     {
         $haystack = mb_strtolower($message);
-        foreach (self::TRIGGERS as $lang => $phrases) {
+        foreach (self::TRIGGERS_STRONG as $lang => $phrases) {
             foreach ($phrases as $p) {
-                if (mb_stripos($haystack, $p) !== false) return $p;
+                if (mb_stripos($haystack, $p) !== false) {
+                    return ['phrase' => $p, 'strong' => true];
+                }
+            }
+        }
+        foreach (self::TRIGGERS_WEAK as $lang => $phrases) {
+            foreach ($phrases as $p) {
+                if (mb_stripos($haystack, $p) !== false) {
+                    return ['phrase' => $p, 'strong' => false];
+                }
             }
         }
         return null;
+    }
+
+    /**
+     * True if the message contains at least one "<field-keyword>:" anchor.
+     * Used to distinguish a structured agent template from a bare legacy
+     * command like "book 2026-04-15 14:00".
+     */
+    private static function hasAnyAnchor(string $message): bool
+    {
+        foreach (self::FIELD_KEYWORDS as $keywords) {
+            foreach ($keywords as $kw) {
+                if (preg_match('/' . preg_quote($kw, '/') . '\s*[:：]/ui', $message)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     // ============================================================

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -2,33 +2,45 @@
 namespace App\Models;
 
 /**
- * AgentBookingParser — v6.3 #120
+ * AgentBookingParser — v6.3 #120 / #132
  *
- * Stateless parser that converts an inbound LINE OA text message from a
- * sales agent into a structured booking record (or a list of validation
- * errors).
+ * Stateless parser that converts an inbound LINE OA text message from an
+ * agent (or, after v6.6, a direct customer) into a structured booking
+ * record — or a list of validation errors.
  *
- * Locked schema (PM call 2026-05-06, see issue #120):
+ * Schema (current — updated in #132):
  *
- *   จองทัวร์    OR    book tour
- *   ทัวร์: <tour_name>           |   tour: <tour_name>
- *   วันที่: <YYYY-MM-DD>         |   date: <YYYY-MM-DD>
- *   ผู้ใหญ่: <int>               |   adults: <int>
- *   เด็ก: <int>                  |   children: <int>
- *   ลูกค้า: <name> <phone>       |   customer: <name> <phone>
- *   ตัวแทน: <agent_code>         |   agent: <agent_code>
- *   หมายเหตุ: <free text>         |   notes: <free text>
+ *   จองทัวร์    OR    book tour                          (strong trigger)
+ *   จอง        OR    book                              (weak trigger — only when paired with field anchors)
  *
- * Required: tour, date, adults, customer, agent.
- * Optional: children, notes.
+ *   ทัวร์: <model_name>             |   tour: <model_name>             (required)
+ *   วันที่ (Travel Date): <YYYY-MM-DD>|   date (Travel Date): <YYYY-MM-DD> (required)
+ *   ผู้ใหญ่: <int>                  |   adults: <int>                  (required)
+ *   เด็ก: <int>                     |   children: <int>                (optional)
+ *   ลูกค้า: <name>                  |   customer: <name>               (required)
+ *   มือถือ: <phone>                 |   mobile: <phone>                (required if ลูกค้า: has no trailing digits)
+ *   อีเมล: <email>                  |   email: <email>                 (optional)
+ *   เมสเซนเจอร์: <id>               |   messenger: <id>                (optional, e.g. line:foo or @bar)
+ *   ตัวแทน: <code>                  |   agent: <code>                  (optional — captured into remark for audit; auto-resolution to agent_id is tracked in #136)
+ *   ที่พัก: <name>                   |   accommodation: <name>          (optional → tour_bookings.pickup_hotel)
+ *   หมายเลขห้อง: <id>                |   room: <id>                     (optional → tour_bookings.pickup_room)
+ *   หมายเหตุ: <free text>            |   notes: <free text>             (optional)
+ *
+ * Backward compatibility: if `ลูกค้า:` includes a trailing phone-like token
+ * and `มือถือ:` is NOT provided, the trailing digits are split off as the
+ * mobile number. This preserves the original v6.3 #120 single-line format.
+ *
+ * Customer contact (name, mobile, email, messenger) is persisted to
+ * `tour_booking_contacts` (not `tour_bookings.booking_by`) — the latter is
+ * reserved for the iACC user who entered the booking.
  *
  * Usage:
  *   $result = AgentBookingParser::parse($messageText);
  *   if ($result['ok']) {
- *       $fields = $result['fields'];   // ['tour_name'=>..., 'date'=>..., 'adults'=>4, ...]
+ *       $fields = $result['fields'];   // ['tour_name'=>..., 'customer_mobile'=>..., 'accommodation'=>..., ...]
  *       $lang   = $result['lang'];     // 'th' | 'en'
  *   } else {
- *       $errors = $result['errors'];   // ['date_missing', 'phone_invalid', ...]
+ *       $errors = $result['errors'];   // ['date_missing', 'phone_invalid', 'mobile_missing', ...]
  *       $lang   = $result['lang'];
  *   }
  */
@@ -60,11 +72,19 @@ class AgentBookingParser
         'adults'         => ['ผู้ใหญ่', 'adults'],
         'children'       => ['เด็ก', 'children'],
         'customer'       => ['ลูกค้า', 'customer'],
+        'mobile'         => ['มือถือ', 'mobile'],
+        'email'          => ['อีเมล', 'email'],
+        'messenger'      => ['เมสเซนเจอร์', 'messenger'],
         'agent_code'     => ['ตัวแทน', 'agent'],
+        'accommodation'  => ['ที่พัก', 'accommodation'],
+        'room'           => ['หมายเลขห้อง', 'room'],
         'notes'          => ['หมายเหตุ', 'notes'],
     ];
 
-    private const REQUIRED_FIELDS = ['tour_name', 'date', 'adults', 'customer', 'agent_code'];
+    // agent_code is no longer required — auto-resolution from the LINE binding
+    // is tracked in #136. Customer phone comes from explicit `มือถือ:` /
+    // `mobile:` keyword (preferred) or trailing digits in `ลูกค้า:` (fallback).
+    private const REQUIRED_FIELDS = ['tour_name', 'date', 'adults', 'customer'];
 
     /**
      * Returns:
@@ -196,12 +216,23 @@ class AgentBookingParser
         // Default children=0 if not provided (optional field)
         $fields['children'] = $fields['children'] ?? 0;
 
-        // Customer field is "<name> <phone>" — split on last whitespace before
-        // a phone-like token so names with spaces work.
+        // Customer field handling:
+        // - If `มือถือ:` / `mobile:` is provided, treat `ลูกค้า:` as the name only.
+        // - Otherwise fall back to the legacy split: `ลูกค้า: <name> <phone>`.
+        // Either way, `customer_mobile` becomes the canonical phone for downstream
+        // validation and persistence.
         if (isset($fields['customer'])) {
-            $split = self::splitCustomer($fields['customer']);
-            $fields['customer_name']  = $split['name'];
-            $fields['customer_phone'] = $split['phone'];
+            $explicitMobile = trim($fields['mobile'] ?? '');
+            if ($explicitMobile !== '') {
+                $fields['customer_name']   = trim($fields['customer']);
+                $fields['customer_phone']  = '';
+                $fields['customer_mobile'] = $explicitMobile;
+            } else {
+                $split = self::splitCustomer($fields['customer']);
+                $fields['customer_name']   = $split['name'];
+                $fields['customer_phone']  = $split['phone'];
+                $fields['customer_mobile'] = $split['phone'];
+            }
         }
 
         return $fields;
@@ -258,8 +289,11 @@ class AgentBookingParser
 
         foreach (self::REQUIRED_FIELDS as $req) {
             if ($req === 'customer') {
-                if (empty($f['customer_name']) || empty($f['customer_phone'])) {
+                if (empty($f['customer_name'])) {
                     $errors[] = 'customer_missing';
+                }
+                if (empty($f['customer_mobile'])) {
+                    $errors[] = 'mobile_missing';
                 }
                 continue;
             }
@@ -279,7 +313,7 @@ class AgentBookingParser
             if ($totalPax < 1) $errors[] = 'pax_too_few';
         }
 
-        if (!empty($f['customer_phone']) && !self::isValidPhone($f['customer_phone'])) {
+        if (!empty($f['customer_mobile']) && !self::isValidPhone($f['customer_mobile'])) {
             $errors[] = 'phone_invalid';
         }
 

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -158,6 +158,112 @@ class LineOA extends BaseModel
         return $result;
     }
 
+    /**
+     * v6.3 #120 — List LINE users with user_type='agent', joined to bound iACC user (if any).
+     * Used by the agent-bindings admin page.
+     */
+    public function getAgentBindings(int $companyId): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT u.id, u.line_user_id, u.display_name, u.picture_url, u.user_type,
+                    u.linked_user_id, u.linked_at, u.linked_by,
+                    a.email AS linked_email, a.name AS linked_name, a.level AS linked_level
+             FROM line_users u
+             LEFT JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             WHERE u.company_id = ? AND u.deleted_at IS NULL
+             ORDER BY (u.user_type = 'agent') DESC, u.display_name ASC"
+        );
+        $stmt->bind_param('i', $companyId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    /**
+     * v6.3 #120 — List iACC users in this company eligible to be bound as agents.
+     */
+    public function getEligibleIaccUsers(int $companyId): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT id, name, email, level FROM authorize
+             WHERE company_id = ? ORDER BY level DESC, name ASC"
+        );
+        $stmt->bind_param('i', $companyId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    /**
+     * v6.3 #120 — Bind a LINE user (must be user_type='agent') to an iACC user.
+     * Returns true on success, false if either user belongs to a different company
+     * or the LINE user is not an agent.
+     */
+    public function bindAgentToUser(int $companyId, int $lineUserDbId, int $iaccUserId, int $adminId): bool
+    {
+        // Verify both rows belong to this tenant + the LINE user is an agent
+        $check = $this->conn->prepare(
+            "SELECT
+                (SELECT COUNT(*) FROM line_users WHERE id = ? AND company_id = ? AND user_type = 'agent' AND deleted_at IS NULL) AS lu_ok,
+                (SELECT COUNT(*) FROM authorize  WHERE id = ? AND company_id = ?) AS au_ok"
+        );
+        $check->bind_param('iiii', $lineUserDbId, $companyId, $iaccUserId, $companyId);
+        $check->execute();
+        $row = $check->get_result()->fetch_assoc();
+        $check->close();
+        if (!$row || (int)$row['lu_ok'] !== 1 || (int)$row['au_ok'] !== 1) return false;
+
+        $stmt = $this->conn->prepare(
+            "UPDATE line_users
+             SET linked_user_id = ?, linked_at = NOW(), linked_by = ?
+             WHERE id = ? AND company_id = ?"
+        );
+        $stmt->bind_param('iiii', $iaccUserId, $adminId, $lineUserDbId, $companyId);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    /**
+     * v6.3 #120 — Remove an agent binding.
+     */
+    public function unbindAgent(int $companyId, int $lineUserDbId): bool
+    {
+        $stmt = $this->conn->prepare(
+            "UPDATE line_users
+             SET linked_user_id = NULL, linked_at = NULL, linked_by = NULL
+             WHERE id = ? AND company_id = ?"
+        );
+        $stmt->bind_param('ii', $lineUserDbId, $companyId);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    /**
+     * v6.3 #120 — Lookup the bound iACC user id for a given LINE userId string.
+     * Returns null if the LINE user isn't an agent or isn't bound.
+     */
+    public function getBoundIaccUserId(int $companyId, string $lineUserIdStr): ?int
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT linked_user_id FROM line_users
+             WHERE company_id = ?
+               AND line_user_id = ?
+               AND user_type = 'agent'
+               AND linked_user_id IS NOT NULL
+               AND deleted_at IS NULL
+             LIMIT 1"
+        );
+        $stmt->bind_param('is', $companyId, $lineUserIdStr);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ? (int)$row['linked_user_id'] : null;
+    }
+
     public function getLineUserByLineId(int $companyId, string $lineUserId): ?array
     {
         $stmt = $this->conn->prepare("SELECT * FROM line_users WHERE company_id = ? AND line_user_id = ? LIMIT 1");

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -275,19 +275,23 @@ class LineOA extends BaseModel
 
     /**
      * v6.3 #132 — Lookup the bound iACC user's authorize record for a given
-     * LINE userId string. Returns ['authorize_id', 'authorize_name', 'email']
+     * LINE userId string. Returns ['authorize_id', 'authorize_name', 'email', 'phone']
      * or null if the LINE user isn't bound (or isn't user_type='agent').
      *
      * Used so the booking write can populate `tour_bookings.booking_by` with
      * the human-readable identity of the agent who entered the booking,
      * instead of the customer's name+phone (the placeholder bug from #120).
+     *
+     * The JOIN deliberately does NOT constrain `authorize.company_id` —
+     * tenancy is already enforced by `bindAgentToUser` at bind time, and
+     * #136 will extend bindings to agent-tenant users (different com_id).
      */
     public function getBoundUserDetails(int $companyId, string $lineUserIdStr): ?array
     {
         $stmt = $this->conn->prepare(
-            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email
+            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email, a.phone
              FROM line_users u
-             JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             JOIN authorize a ON a.id = u.linked_user_id
              WHERE u.company_id = ?
                AND u.line_user_id = ?
                AND u.user_type = 'agent'

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -243,6 +243,37 @@ class LineOA extends BaseModel
     }
 
     /**
+     * v6.3 #120 — Update a LINE user's user_type ('customer' | 'agent').
+     * Returns false if the row doesn't belong to this tenant or the type is invalid.
+     * If user_type is being changed away from 'agent', any existing binding is also cleared.
+     */
+    public function updateUserType(int $companyId, int $lineUserDbId, string $userType): bool
+    {
+        if (!in_array($userType, ['customer', 'agent'], true)) return false;
+
+        if ($userType === 'agent') {
+            $stmt = $this->conn->prepare(
+                "UPDATE line_users SET user_type = ?
+                 WHERE id = ? AND company_id = ? AND deleted_at IS NULL"
+            );
+            $stmt->bind_param('sii', $userType, $lineUserDbId, $companyId);
+        } else {
+            // Demoting from agent — also clear any existing binding so a stale
+            // linked_user_id can't be reactivated by re-promoting later.
+            $stmt = $this->conn->prepare(
+                "UPDATE line_users
+                 SET user_type = ?, linked_user_id = NULL, linked_at = NULL, linked_by = NULL
+                 WHERE id = ? AND company_id = ? AND deleted_at IS NULL"
+            );
+            $stmt->bind_param('sii', $userType, $lineUserDbId, $companyId);
+        }
+        $ok = $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+        return $ok && $affected >= 0;
+    }
+
+    /**
      * v6.3 #120 — Lookup the bound iACC user id for a given LINE userId string.
      * Returns null if the LINE user isn't an agent or isn't bound.
      */

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -274,6 +274,35 @@ class LineOA extends BaseModel
     }
 
     /**
+     * v6.3 #132 — Lookup the bound iACC user's authorize record for a given
+     * LINE userId string. Returns ['authorize_id', 'authorize_name', 'email']
+     * or null if the LINE user isn't bound (or isn't user_type='agent').
+     *
+     * Used so the booking write can populate `tour_bookings.booking_by` with
+     * the human-readable identity of the agent who entered the booking,
+     * instead of the customer's name+phone (the placeholder bug from #120).
+     */
+    public function getBoundUserDetails(int $companyId, string $lineUserIdStr): ?array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email
+             FROM line_users u
+             JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             WHERE u.company_id = ?
+               AND u.line_user_id = ?
+               AND u.user_type = 'agent'
+               AND u.linked_user_id IS NOT NULL
+               AND u.deleted_at IS NULL
+             LIMIT 1"
+        );
+        $stmt->bind_param('is', $companyId, $lineUserIdStr);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ?: null;
+    }
+
+    /**
      * v6.3 #120 — Lookup the bound iACC user id for a given LINE userId string.
      * Returns null if the LINE user isn't an agent or isn't bound.
      */

--- a/app/Models/TourBooking.php
+++ b/app/Models/TourBooking.php
@@ -272,10 +272,10 @@ class TourBooking extends BaseModel
                  pickup_location_id, pickup_hotel, pickup_room, pickup_time,
                  driver_name, vehicle_no,
                  voucher_number, entrance_fee, subtotal, discount, vat, total_amount, currency,
-                 status, remark, created_by";
+                 status, remark, created_by, created_via";
 
         $vals = sprintf(
-            "'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s'",
+            "'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s'",
             intval($data['company_id']),
             sql_escape($data['booking_number']),
             sql_escape($data['booking_date'] ?? date('Y-m-d')),
@@ -302,7 +302,8 @@ class TourBooking extends BaseModel
             sql_escape($data['currency'] ?? 'THB'),
             sql_escape($data['status'] ?? 'draft'),
             sql_escape($data['remark'] ?? ''),
-            intval($data['created_by'] ?? 0)
+            intval($data['created_by'] ?? 0),
+            sql_escape($data['created_via'] ?? 'web_form')
         );
 
         $args = [];

--- a/app/Models/TourBooking.php
+++ b/app/Models/TourBooking.php
@@ -9,6 +9,31 @@ class TourBooking extends BaseModel
     // ─── Booking Number ────────────────────────────────────────
 
     /**
+     * Resolve a booking's `status` based on tour_allotments availability.
+     * Centralized so every booking write path (web form, LINE agent text,
+     * LINE customer direct in v6.6, future channels) reaches the same
+     * verdict from the same data.
+     *
+     * Returns ['status' => 'confirmed'|'draft', 'reason' => 'available'|'no_allotment'|'closed'|'overbook'].
+     *
+     * Decision matrix:
+     *   - No allotment configured for the date  → 'draft' / 'no_allotment'
+     *   - Allotment row exists but is_closed=1  → 'draft' / 'closed'
+     *   - requestedPax > available              → 'draft' / 'overbook'
+     *   - Otherwise                             → 'confirmed' / 'available'
+     */
+    public function resolveBookingStatus(int $companyId, string $travelDate, int $requestedPax): array
+    {
+        $allotmentModel = new \App\Models\TourAllotment();
+        $alloc = $allotmentModel->getAllotmentByDate($companyId, $travelDate);
+
+        if (!$alloc)                                   return ['status' => 'draft',     'reason' => 'no_allotment'];
+        if (!empty($alloc['is_closed']))               return ['status' => 'draft',     'reason' => 'closed'];
+        if ($requestedPax > intval($alloc['available'])) return ['status' => 'draft',   'reason' => 'overbook'];
+        return ['status' => 'confirmed', 'reason' => 'available'];
+    }
+
+    /**
      * Generate next booking number: BK-YYMMDD-001
      */
     public function generateBookingNumber(int $comId): string

--- a/app/Views/line-oa/_nav.php
+++ b/app/Views/line-oa/_nav.php
@@ -17,6 +17,7 @@ $_navItems = [
     'line_messages'     => ['icon' => 'fa-comments',        'en' => 'Messages',     'th' => 'ข้อความ'],
     'line_users'        => ['icon' => 'fa-users',           'en' => 'Users',        'th' => 'ผู้ใช้'],
     'line_auto_replies' => ['icon' => 'fa-reply-all',       'en' => 'Auto Replies', 'th' => 'ตอบกลับอัตโนมัติ'],
+    'line_agent_bindings' => ['icon' => 'fa-link',          'en' => 'Agent Bindings', 'th' => 'ผูกบัญชีตัวแทน'],
     'line_templates'    => ['icon' => 'fa-clone',           'en' => 'Templates',    'th' => 'เทมเพลต'],
     'line_broadcasts'   => ['icon' => 'fa-bullhorn',        'en' => 'Broadcasts',   'th' => 'ส่งกลุ่ม'],
     'line_send_message' => ['icon' => 'fa-paper-plane',     'en' => 'Send Message', 'th' => 'ส่งข้อความ'],

--- a/app/Views/line-oa/agent-bindings.php
+++ b/app/Views/line-oa/agent-bindings.php
@@ -1,0 +1,143 @@
+<?php
+$pageTitle = 'LINE OA — Agent Bindings';
+$lang = (isset($_SESSION['lang']) && $_SESSION['lang'] == 1) ? 'th' : 'en';
+$isThai = ($lang === 'th');
+$labels = [
+    'en' => [
+        'page_title'   => 'Agent Bindings',
+        'intro'        => 'Bind LINE OA agent accounts to iACC user accounts. Only bound agents can submit bookings via structured LINE messages (e.g. <code>book tour</code>).',
+        'agent_users'  => 'Agent LINE Users',
+        'display_name' => 'Display Name',
+        'line_id'      => 'LINE userId',
+        'user_type'    => 'Type',
+        'bound_to'     => 'Bound iACC User',
+        'select_user'  => 'Select user…',
+        'bind'         => 'Bind',
+        'unbind'       => 'Unbind',
+        'change'       => 'Change',
+        'no_users'     => 'No LINE users yet — they will appear here once a user adds your OA as a friend.',
+        'no_agents'    => 'No LINE users currently flagged as agents. Open the Users page and change a user\'s type to "agent" first.',
+        'how_title'    => 'How to register a LINE user as an agent',
+        'step1'        => '1. The user adds your LINE OA as a friend.',
+        'step2'        => '2. Open the <a href="index.php?page=line_users">Users</a> page and change their <strong>user_type</strong> to <strong>agent</strong>.',
+        'step3'        => '3. Return here and bind their LINE account to an iACC user.',
+        'unbound'      => '— not bound —',
+    ],
+    'th' => [
+        'page_title'   => 'ผูกบัญชีตัวแทน',
+        'intro'        => 'ผูกบัญชี LINE ของตัวแทนเข้ากับบัญชีผู้ใช้ iACC เฉพาะตัวแทนที่ผูกบัญชีแล้วเท่านั้น จึงจะส่งการจองผ่าน LINE ได้ (เช่นพิมพ์ <code>จองทัวร์</code>)',
+        'agent_users'  => 'รายชื่อผู้ใช้ LINE ที่เป็นตัวแทน',
+        'display_name' => 'ชื่อที่แสดง',
+        'line_id'      => 'LINE userId',
+        'user_type'    => 'ประเภท',
+        'bound_to'     => 'ผูกกับผู้ใช้ iACC',
+        'select_user'  => 'เลือกผู้ใช้…',
+        'bind'         => 'ผูก',
+        'unbind'       => 'ยกเลิก',
+        'change'       => 'เปลี่ยน',
+        'no_users'     => 'ยังไม่มีผู้ใช้ LINE — จะแสดงเมื่อผู้ใช้เพิ่ม OA เป็นเพื่อน',
+        'no_agents'    => 'ยังไม่มีผู้ใช้ LINE ที่ระบุเป็น "agent" กรุณาเปิดหน้า Users และเปลี่ยน user_type เป็น "agent" ก่อน',
+        'how_title'    => 'วิธีลงทะเบียนผู้ใช้ LINE เป็นตัวแทน',
+        'step1'        => '1. ให้ผู้ใช้เพิ่ม LINE OA ของคุณเป็นเพื่อน',
+        'step2'        => '2. ไปที่หน้า <a href="index.php?page=line_users">Users</a> แล้วเปลี่ยน <strong>user_type</strong> เป็น <strong>agent</strong>',
+        'step3'        => '3. กลับมาที่หน้านี้เพื่อผูกบัญชีกับผู้ใช้ iACC',
+        'unbound'      => '— ยังไม่ผูก —',
+    ],
+];
+$t = $labels[$lang];
+
+$agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] ?? '') === 'agent'));
+?>
+<?php $currentNavPage = 'line_agent_bindings'; include __DIR__ . '/_nav.php'; ?>
+
+<?php if (!empty($_SESSION['flash_success'])): ?>
+<div class="alert alert-success alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_success'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_success']); endif; ?>
+<?php if (!empty($_SESSION['flash_error'])): ?>
+<div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
+<?php unset($_SESSION['flash_error']); endif; ?>
+
+<div style="display:flex; gap:20px; flex-wrap:wrap;">
+
+<div style="flex:2; min-width:380px;">
+    <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+        <h4 style="margin-top:0;"><i class="fa fa-link"></i> <?= $t['agent_users'] ?></h4>
+        <p style="color:#666;"><?= $t['intro'] ?></p>
+
+        <?php if (empty($agents)): ?>
+            <p style="text-align:center; padding:30px 20px; color:#999;"><?= $t['no_agents'] ?></p>
+        <?php else: ?>
+        <div class="table-responsive">
+            <table class="table table-hover" style="margin:0;">
+                <thead>
+                    <tr>
+                        <th><?= $t['display_name'] ?></th>
+                        <th><?= $t['line_id'] ?></th>
+                        <th><?= $t['bound_to'] ?></th>
+                        <th style="text-align:right;"><?= $t['bind'] ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($agents as $a): ?>
+                    <?php $isBound = !empty($a['linked_user_id']); ?>
+                    <tr>
+                        <td>
+                            <?php if (!empty($a['picture_url'])): ?>
+                                <img src="<?= htmlspecialchars($a['picture_url'], ENT_QUOTES, 'UTF-8') ?>" alt="" style="width:24px; height:24px; border-radius:50%; vertical-align:middle; margin-right:6px;">
+                            <?php endif; ?>
+                            <strong><?= htmlspecialchars($a['display_name'] ?? '', ENT_QUOTES, 'UTF-8') ?></strong>
+                        </td>
+                        <td><code style="font-size:0.75rem;"><?= htmlspecialchars(substr($a['line_user_id'] ?? '', 0, 12), ENT_QUOTES, 'UTF-8') ?>…</code></td>
+                        <td>
+                            <?php if ($isBound): ?>
+                                <span class="label label-success">
+                                    <i class="fa fa-check"></i>
+                                    <?= htmlspecialchars($a['linked_name'] ?: $a['linked_email'] ?: ('#' . $a['linked_user_id']), ENT_QUOTES, 'UTF-8') ?>
+                                </span>
+                                <?php if (!empty($a['linked_at'])): ?>
+                                    <small class="text-muted" style="display:block;"><?= date('M d, Y', strtotime($a['linked_at'])) ?></small>
+                                <?php endif; ?>
+                            <?php else: ?>
+                                <span class="text-muted"><?= $t['unbound'] ?></span>
+                            <?php endif; ?>
+                        </td>
+                        <td style="text-align:right;">
+                            <form method="POST" action="index.php?page=line_agent_bind_save" style="display:inline-flex; gap:5px; align-items:center;">
+                                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                                <input type="hidden" name="line_user_id" value="<?= (int)$a['id'] ?>">
+                                <select name="iacc_user_id" class="form-control input-sm" style="max-width:180px;">
+                                    <option value=""><?= $t['select_user'] ?></option>
+                                    <?php foreach (($iaccUsers ?? []) as $u): ?>
+                                        <option value="<?= (int)$u['id'] ?>" <?= ($a['linked_user_id'] ?? 0) == $u['id'] ? 'selected' : '' ?>>
+                                            <?= htmlspecialchars(($u['name'] ?: $u['email']) . ' (lvl ' . (int)$u['level'] . ')', ENT_QUOTES, 'UTF-8') ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <button type="submit" name="action" value="bind" class="btn btn-sm btn-primary"><i class="fa fa-link"></i></button>
+                                <?php if ($isBound): ?>
+                                    <button type="submit" name="action" value="unbind" class="btn btn-sm btn-outline-danger" onclick="return confirm('Unbind this agent?');"><i class="fa fa-unlink"></i></button>
+                                <?php endif; ?>
+                            </form>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<div style="flex:1; min-width:280px;">
+    <div style="background:#f9f9f9; border-radius:12px; padding:20px; border-left:4px solid #06C755;">
+        <h5 style="margin-top:0;"><i class="fa fa-question-circle"></i> <?= $t['how_title'] ?></h5>
+        <ol style="padding-left:0; list-style:none; line-height:2;">
+            <li><?= $t['step1'] ?></li>
+            <li><?= $t['step2'] ?></li>
+            <li><?= $t['step3'] ?></li>
+        </ol>
+    </div>
+</div>
+
+</div>
+</div>

--- a/app/Views/line-oa/users.php
+++ b/app/Views/line-oa/users.php
@@ -22,6 +22,8 @@ $labels = [
         'send_message' => 'Send',
         'no_users' => 'No LINE users found.',
         'joined' => 'Joined',
+        'save' => 'Save',
+        'change_type_hint' => 'Change to "Agent" before binding to an iACC user on the Agent Bindings page.',
     ],
     'th' => [
         'page_title' => 'ผู้ใช้ LINE',
@@ -39,6 +41,8 @@ $labels = [
         'send_message' => 'ส่ง',
         'no_users' => 'ไม่พบผู้ใช้ LINE',
         'joined' => 'เข้าร่วม',
+        'save' => 'บันทึก',
+        'change_type_hint' => 'เปลี่ยนเป็น "ตัวแทน" ก่อนจึงจะผูกบัญชีกับผู้ใช้ iACC ในหน้า Agent Bindings ได้',
     ]
 ];
 $t = $labels[$lang];
@@ -91,7 +95,17 @@ $t = $labels[$lang];
                             <?php endif; ?>
                         </td>
                         <td><?= htmlspecialchars($lu['display_name'] ?? '-', ENT_QUOTES, 'UTF-8') ?></td>
-                        <td><span class="label label-<?= $lu['user_type'] === 'agent' ? 'primary' : 'info' ?>"><?= $t[$lu['user_type']] ?? $lu['user_type'] ?></span></td>
+                        <td>
+                            <form method="POST" action="index.php?page=line_user_type_update" style="display:inline-flex; gap:4px; align-items:center; margin:0;">
+                                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                                <input type="hidden" name="line_user_id" value="<?= (int)$lu['id'] ?>">
+                                <select name="user_type" class="form-control input-sm" style="max-width:110px;" title="<?= htmlspecialchars($t['change_type_hint'], ENT_QUOTES, 'UTF-8') ?>">
+                                    <option value="customer" <?= ($lu['user_type'] ?? '') === 'customer' ? 'selected' : '' ?>><?= $t['customer'] ?></option>
+                                    <option value="agent" <?= ($lu['user_type'] ?? '') === 'agent' ? 'selected' : '' ?>><?= $t['agent'] ?></option>
+                                </select>
+                                <button type="submit" class="btn btn-xs btn-primary" title="<?= $t['save'] ?>"><i class="fa fa-save"></i></button>
+                            </form>
+                        </td>
                         <td>
                             <?php if ($lu['is_blocked']): ?>
                             <span class="label label-danger"><?= $t['blocked'] ?></span>

--- a/database/migrations/2026_05_06_v6_3_120_agent_text_booking.sql
+++ b/database/migrations/2026_05_06_v6_3_120_agent_text_booking.sql
@@ -1,0 +1,70 @@
+-- Migration: 2026_05_06_v6_3_120_agent_text_booking.sql
+-- v6.3 #120 — Agent text-template booking via LINE OA
+-- Adds: tour_bookings.created_via (source attribution), line_users binding-audit columns
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+-- Idempotent via stored-procedure column-existence checks
+
+DROP PROCEDURE IF EXISTS _migrate_v63_120;
+DELIMITER $$
+CREATE PROCEDURE _migrate_v63_120()
+BEGIN
+    -- 1. tour_bookings.created_via — tracks where the booking originated
+    --    (web_form, line_oa_agent_text, line_oa_agent_file, line_oa_agent_image, csv_import, ...)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'tour_bookings'
+          AND COLUMN_NAME  = 'created_via'
+    ) THEN
+        ALTER TABLE `tour_bookings`
+            ADD COLUMN `created_via` VARCHAR(50) DEFAULT NULL
+            COMMENT 'Source channel: web_form, line_oa_agent_text, line_oa_agent_file, line_oa_agent_image, csv_import';
+    END IF;
+
+    -- 2. tour_bookings index on created_via for source-channel reporting
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'tour_bookings'
+          AND INDEX_NAME   = 'idx_tb_created_via'
+    ) THEN
+        CREATE INDEX `idx_tb_created_via` ON `tour_bookings` (`created_via`);
+    END IF;
+
+    -- 3. line_users.linked_at — when the binding was created (audit)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_users'
+          AND COLUMN_NAME  = 'linked_at'
+    ) THEN
+        ALTER TABLE `line_users`
+            ADD COLUMN `linked_at` DATETIME DEFAULT NULL
+            COMMENT 'When linked_user_id was bound by an admin';
+    END IF;
+
+    -- 4. line_users.linked_by — which admin did the binding (audit)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_users'
+          AND COLUMN_NAME  = 'linked_by'
+    ) THEN
+        ALTER TABLE `line_users`
+            ADD COLUMN `linked_by` INT DEFAULT NULL
+            COMMENT 'FK to authorize.id of the admin who created the binding';
+    END IF;
+
+    -- 5. line_users index on linked_user_id for fast bound-agent lookup
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'line_users'
+          AND INDEX_NAME   = 'idx_lu_linked_user'
+    ) THEN
+        CREATE INDEX `idx_lu_linked_user` ON `line_users` (`linked_user_id`);
+    END IF;
+END$$
+DELIMITER ;
+CALL _migrate_v63_120();
+DROP PROCEDURE IF EXISTS _migrate_v63_120;

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -184,6 +184,25 @@ function handleMessage(array $event, int $companyId, int $dbUserId, \App\Models\
         // Check for order keywords
         $lowerContent = mb_strtolower($content);
 
+        // v6.3 #120 — Agent text-template booking (intercept before legacy commands).
+        // ingestText() returns handled=false when no booking trigger, so we fall
+        // through to the existing order/book/status/auto-reply chain.
+        $lineUserIdStr = $event['source']['userId'] ?? '';
+        if ($lineUserIdStr !== '') {
+            $agentResult = \App\Controllers\LineAgentController::ingestText($companyId, $content, $lineUserIdStr);
+            if (!empty($agentResult['handled'])) {
+                if (!empty($agentResult['reply_messages'])) {
+                    $service->replyMessage($replyToken, $agentResult['reply_messages']);
+                    foreach ($agentResult['reply_messages'] as $msg) {
+                        $msgType = $msg['type'] ?? 'text';
+                        $msgContent = $msgType === 'text' ? ($msg['text'] ?? '') : json_encode($msg);
+                        $model->logMessage($companyId, $dbUserId, 'outbound', $msgType, null, null, $msgContent);
+                    }
+                }
+                return;
+            }
+        }
+
         // Order command: "order <items>"
         if (preg_match('/^(order|สั่ง|สั่งซื้อ)\s+(.+)/iu', $content, $matches)) {
             handleOrderCommand($replyToken, $companyId, $dbUserId, $matches[2], $model, $service);

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -27,6 +27,12 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/inc/sys.configs.php';
 require_once __DIR__ . '/inc/class.dbconn.php';
 require_once __DIR__ . '/inc/class.hard.php';
+// inc/security.php — needed by App\Models\TourBooking::createBooking and other
+// model methods that use sql_escape() / sql_int() / sql_float(). The normal
+// page bootstrap (index.php) loads this; the webhook bootstrap was missing it,
+// which caused a fatal "Call to undefined function sql_escape()" inside
+// agent text-template booking writes.
+require_once __DIR__ . '/inc/security.php';
 
 // Autoloader for App namespace
 spl_autoload_register(function ($class) {


### PR DESCRIPTION
# v6.3 production release — Agent Booking Capture (LINE OA structured booking)

Promotes `develop` → `main`. Closes the v6.3 milestone.

## Headline

Sales agents bound to a LINE OA account can now send a structured TH/EN text-template message and have a row created in `tour_bookings` (with proper customer contact, accommodation, allotment-aware status) immediately — attributed to their bound iACC user.

## What ships

### Feature work
- **[#120](https://github.com/psinthorn/iacc-php-mvc/issues/120) — Agent text-template booking via LINE OA** (PR #124)
  - Bilingual TH+EN trigger detection (`จองทัวร์` / `book tour` strong; `จอง` / `book` weak with anchor requirement)
  - 12 structured field keywords, case-insensitive
  - Tour name fuzzy-matched against `model` + `type` tables
  - Booking write to `tour_bookings` with `created_via='line_oa_agent_text'`
  - Bilingual success Flex (✅ Confirmed / ⏳ Pending Review) + error Flex
  - LINE webhook signature validation unchanged; multi-tenant isolation preserved
- **[#132](https://github.com/psinthorn/iacc-php-mvc/issues/132) — Field semantics + customer contacts + allotment-aware status** (PR #137)
  - `booking_by` set to bound iACC user's identity (name → email → "User #ID")
  - Customer contact (name, mobile, email, messenger) → `tour_booking_contacts`
  - Accommodation + room → `pickup_hotel`, `pickup_room`
  - New `TourBooking::resolveBookingStatus` consults `TourAllotment::getAllotmentByDate` to auto-confirm or hold for review
  - When status falls to draft due to allotment, `line_webhook_events` row with `event_type='allotment_blocked'` for operator visibility
- **PR #126** — User Type editor on LINE Users page (admins can flip `customer ↔ agent` via UI; demotion clears bindings)

### Schema migrations
- `database/migrations/2026_05_06_v6_3_120_agent_text_booking.sql` — adds `tour_bookings.created_via`, `line_users.linked_at`, `line_users.linked_by` + indexes; idempotent via stored-procedure column-existence checks (cPanel-friendly)

### Fixes ironed out during staging verification
| PR | Fix |
|---|---|
| #125 | matchTour: query `model`/`type` instead of non-existent `tour_products` |
| #126 | Add user_type editor (admins couldn't promote LINE users to `agent` without DB access) |
| #127 | Pin LIKE collation (utf8mb4_unicode_ci) — silent webhook fail on staging |
| #128 | Booking number format `BK-YYMMDD-NNN` (canonical, matches web form) |
| #129 | Status enum `'draft'` (was `'pending'` — not in enum) + write-error logging to `line_webhook_events` |
| #130 | Weak trigger expansion (`จอง` / `book` accepted when paired with structured anchors) |
| #131 | Webhook bootstrap loads `inc/security.php` (`sql_escape()` was undefined in webhook context) |
| #138 | booking_by fallback chain (name → email → "User #ID") + JOIN cleanup |

## Non-negotiable platform rules — verified

- ✅ **Multi-tenant isolation**: every query filters by `company_id`; bind action verifies both LINE user AND iACC user belong to the same tenant
- ✅ **Bilingual TH+EN**: triggers, field keywords, validation labels, success Flex, error Flex, allotment reason copy
- ✅ **Mobile-friendly**: agent bindings + LINE users pages render at 320px
- ✅ **cPanel-compatible**: idempotent migration via stored procedure; no CLI required for deploy
- ✅ **CSRF + level≥2 guards**: bindings page actions and user-type editor

## Production deploy plan

1. Merge this PR → main → production auto-deploy hook fires
2. **Run the migration once on production phpMyAdmin** (it's idempotent; safe to run pre/during/post file deploy):
   ```
   database/migrations/2026_05_06_v6_3_120_agent_text_booking.sql
   ```
3. Verify columns + indexes:
   ```sql
   SHOW COLUMNS FROM tour_bookings LIKE 'created_via';
   SHOW COLUMNS FROM line_users LIKE 'linked_%';
   SHOW INDEX FROM tour_bookings WHERE Key_name = 'idx_tb_created_via';
   SHOW INDEX FROM line_users    WHERE Key_name = 'idx_lu_linked_user';
   ```
4. Configure (per tenant) — admin actions, no code:
   - Pick a LINE user from `index.php?page=line_users` and set their type to `agent`
   - Bind that LINE account to an iACC user from `index.php?page=line_agent_bindings`
5. Smoke test on production:
   - Send `จองทัวร์` template via LINE → expect green ✅ Flex with `BK-YYMMDD-NNN`
   - Verify booking row + `tour_booking_contacts` child row + correct `booking_by`

## Deferred (not in this release)

- **#136** — Extend bind UI to support agent-tenant users + auto-resolve `tour_bookings.agent_id`. Stays on v6.3 milestone; will ship as a v6.3.1 follow-up.
- **#133** — v6.4: Move LINE agent Flex templates into self-serve `line_templates` module
- **#134 / #135** — v6.6: Customer-direct booking + Flex carousel tour selection

## Test plan (post-deploy)

- [ ] Migration runs cleanly on production phpMyAdmin (no errors, columns and indexes present)
- [ ] One real agent on at least one tenant successfully sends the structured template via LINE and receives the green Flex with `BK-YYMMDD-NNN`
- [ ] `tour_bookings` row contains correct `created_via='line_oa_agent_text'`, `booking_by` showing the agent's iACC identity, and `pickup_hotel`/`pickup_room` populated when the message included those fields
- [ ] `tour_booking_contacts` child row present with name, mobile, email (when provided), messenger (when provided)
- [ ] Allotment-aware status: a tenant with allotment configured for the test date sees `status='confirmed'`; a tenant without allotment sees `status='draft'` + the orange ⏳ Flex
- [ ] Legacy v6.2 customer flow (`book <date> <time>`) continues to work — does NOT hit the agent intercept (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
