### PR TITLE
feat(v6.3): #136 — extend bind UI to agent-tenant users + auto agent_id

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -38,10 +38,17 @@ class LineAgentController extends BaseController
         }
         $companyId = (int)$this->user['com_id'];
         $bindings  = $this->lineModel->getAgentBindings($companyId);
-        $iaccUsers = $this->lineModel->getEligibleIaccUsers($companyId);
+        // #136: two scopes — operator's own team vs registered agent partners.
+        // The view renders both as tabs so admins can pick the right pool of
+        // iACC users when binding a LINE account.
+        $iaccUsers         = $this->lineModel->getEligibleIaccUsers($companyId);
+        $agentTenantUsers  = $this->lineModel->getEligibleAgentTenantUsers($companyId);
+        $scope             = ($_GET['scope'] ?? 'team') === 'partners' ? 'partners' : 'team';
         $this->render('line-oa/agent-bindings', [
-            'bindings'  => $bindings,
-            'iaccUsers' => $iaccUsers,
+            'bindings'         => $bindings,
+            'iaccUsers'        => $iaccUsers,
+            'agentTenantUsers' => $agentTenantUsers,
+            'scope'            => $scope,
         ]);
     }
 
@@ -209,6 +216,17 @@ class LineAgentController extends BaseController
             $bookingByName = 'User #' . $iaccUserId;
         }
 
+        // #136: auto-resolve agent_id from the bound user. If the bound user
+        // belongs to an agent-partner tenant, this returns the matching
+        // tour_agent_profiles.id and the booking is attributed to that
+        // partner for commission tracking. Operator's own employees return
+        // null (agent_id stays 0 — they're sales reps, not partner agents).
+        $resolvedAgentId = 0;
+        if ($boundUser && !empty($boundUser['user_com_id'])) {
+            $aid = $line->resolveAgentIdFromBoundUser($companyId, (int)$boundUser['user_com_id']);
+            if ($aid) $resolvedAgentId = $aid;
+        }
+
         // Compose remark — captures the tour name + any agent notes +
         // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id
         // is deferred to #136 once the bind UI supports agent-tenant users).
@@ -235,7 +253,7 @@ class LineAgentController extends BaseController
                 'booking_number' => $bookingNumber,
                 'booking_date'   => date('Y-m-d'),
                 'travel_date'    => $fields['date'],
-                'agent_id'       => 0, // deferred to #136
+                'agent_id'       => $resolvedAgentId, // #136: auto from binding when partner-tenant
                 'sales_rep_id'   => 0,
                 'customer_id'    => 0,
                 'booking_by'     => $bookingByName,

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -164,12 +164,28 @@ class LineOA extends BaseModel
      */
     public function getAgentBindings(int $companyId): array
     {
+        // #136: relaxed the `a.company_id = u.company_id` constraint so
+        // agent-tenant bindings (where the bound authorize user lives in a
+        // partner agent's tenant) display correctly. The bind action still
+        // enforces the partner-relationship via tour_agent_profiles, so this
+        // JOIN doesn't grant access — it only renders what's already valid.
+        // The agent partner's company name (when applicable) is fetched via
+        // a second LEFT JOIN through the partner registration so the UI can
+        // label which company a binding belongs to.
         $stmt = $this->conn->prepare(
             "SELECT u.id, u.line_user_id, u.display_name, u.picture_url, u.user_type,
                     u.linked_user_id, u.linked_at, u.linked_by,
-                    a.email AS linked_email, a.name AS linked_name, a.level AS linked_level
+                    a.email AS linked_email, a.name AS linked_name, a.level AS linked_level,
+                    a.company_id AS linked_user_com_id,
+                    partner.name_en AS partner_company_en,
+                    partner.name_th AS partner_company_th
              FROM line_users u
-             LEFT JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             LEFT JOIN authorize a ON a.id = u.linked_user_id
+             LEFT JOIN tour_agent_profiles tap
+                    ON tap.company_ref_id = a.company_id
+                   AND tap.company_id     = u.company_id
+                   AND tap.deleted_at IS NULL
+             LEFT JOIN company partner ON partner.id = tap.company_ref_id
              WHERE u.company_id = ? AND u.deleted_at IS NULL
              ORDER BY (u.user_type = 'agent') DESC, u.display_name ASC"
         );
@@ -182,6 +198,7 @@ class LineOA extends BaseModel
 
     /**
      * v6.3 #120 — List iACC users in this company eligible to be bound as agents.
+     * "My Team" mode — operator's own employees.
      */
     public function getEligibleIaccUsers(int $companyId): array
     {
@@ -197,19 +214,93 @@ class LineOA extends BaseModel
     }
 
     /**
+     * v6.3 #136 — List authorize users from agent-partner tenants for this
+     * operator. "Agent Partners" mode — employees of B2B partners that are
+     * registered with this operator via tour_agent_profiles.
+     *
+     * Each row includes the agent company's display labels (name_en/name_th)
+     * so the bind UI can label the dropdown clearly. Filters out agents with
+     * an expired contract (contract_end < CURDATE()) so admins don't bind to
+     * relationships that no longer exist.
+     */
+    public function getEligibleAgentTenantUsers(int $operatorCompanyId): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT a.id, a.name, a.email, a.level,
+                    a.company_id   AS user_com_id,
+                    c.name_en      AS agent_company_en,
+                    c.name_th      AS agent_company_th,
+                    tap.id         AS agent_profile_id
+             FROM authorize a
+             JOIN tour_agent_profiles tap
+               ON tap.company_ref_id = a.company_id
+              AND tap.deleted_at IS NULL
+             JOIN company c
+               ON c.id = a.company_id
+             WHERE tap.company_id = ?
+               AND (tap.contract_end IS NULL OR tap.contract_end >= CURDATE())
+             ORDER BY c.name_en ASC, a.level DESC, a.name ASC"
+        );
+        $stmt->bind_param('i', $operatorCompanyId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    /**
+     * v6.3 #136 — Resolve a tour_agent_profiles.id from the bound iACC user.
+     *
+     * Returns the agent profile id if the user belongs to a partner agent
+     * tenant registered with this operator. Returns null if the user is in
+     * the operator's own tenant (own-team / sales rep — agent_id stays null)
+     * or if no matching profile is found.
+     */
+    public function resolveAgentIdFromBoundUser(int $operatorCompanyId, int $boundUserComId): ?int
+    {
+        if ($boundUserComId === $operatorCompanyId) return null; // own-team — not a partner agent
+        $stmt = $this->conn->prepare(
+            "SELECT id FROM tour_agent_profiles
+             WHERE company_id = ?
+               AND company_ref_id = ?
+               AND deleted_at IS NULL
+             ORDER BY id ASC
+             LIMIT 1"
+        );
+        $stmt->bind_param('ii', $operatorCompanyId, $boundUserComId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ? (int)$row['id'] : null;
+    }
+
+    /**
      * v6.3 #120 — Bind a LINE user (must be user_type='agent') to an iACC user.
-     * Returns true on success, false if either user belongs to a different company
-     * or the LINE user is not an agent.
+     *
+     * v6.3 #136 — Auth check expanded: the iACC user must be EITHER
+     *   (a) in the operator's own tenant (operator employee / sales rep), OR
+     *   (b) in a tenant whose company_id appears in tour_agent_profiles.company_ref_id
+     *       for this operator (agent partner employee).
+     *
+     * Returns true on success, false if the line_user isn't in this tenant /
+     * isn't user_type='agent', or the iACC user isn't reachable from this
+     * operator under either rule.
      */
     public function bindAgentToUser(int $companyId, int $lineUserDbId, int $iaccUserId, int $adminId): bool
     {
-        // Verify both rows belong to this tenant + the LINE user is an agent
         $check = $this->conn->prepare(
             "SELECT
-                (SELECT COUNT(*) FROM line_users WHERE id = ? AND company_id = ? AND user_type = 'agent' AND deleted_at IS NULL) AS lu_ok,
-                (SELECT COUNT(*) FROM authorize  WHERE id = ? AND company_id = ?) AS au_ok"
+                (SELECT COUNT(*) FROM line_users
+                 WHERE id = ? AND company_id = ? AND user_type = 'agent' AND deleted_at IS NULL) AS lu_ok,
+                (SELECT COUNT(*) FROM authorize a
+                 WHERE a.id = ?
+                   AND (a.company_id = ?
+                        OR a.company_id IN (
+                            SELECT company_ref_id FROM tour_agent_profiles
+                            WHERE company_id = ? AND deleted_at IS NULL
+                        ))) AS au_ok"
         );
-        $check->bind_param('iiii', $lineUserDbId, $companyId, $iaccUserId, $companyId);
+        $check->bind_param('iiiii', $lineUserDbId, $companyId, $iaccUserId, $companyId, $companyId);
         $check->execute();
         $row = $check->get_result()->fetch_assoc();
         $check->close();
@@ -288,8 +379,13 @@ class LineOA extends BaseModel
      */
     public function getBoundUserDetails(int $companyId, string $lineUserIdStr): ?array
     {
+        // user_com_id is added in #136 so callers can pass it to
+        // resolveAgentIdFromBoundUser() — when the bound user belongs to an
+        // agent tenant (different company_id), we resolve to the operator's
+        // tour_agent_profiles row instead of treating them as an own-team rep.
         $stmt = $this->conn->prepare(
-            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email, a.phone
+            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email, a.phone,
+                    a.company_id AS user_com_id
              FROM line_users u
              JOIN authorize a ON a.id = u.linked_user_id
              WHERE u.company_id = ?

--- a/app/Views/line-oa/agent-bindings.php
+++ b/app/Views/line-oa/agent-bindings.php
@@ -22,6 +22,9 @@ $labels = [
         'step2'        => '2. Open the <a href="index.php?page=line_users">Users</a> page and change their <strong>user_type</strong> to <strong>agent</strong>.',
         'step3'        => '3. Return here and bind their LINE account to an iACC user.',
         'unbound'      => '— not bound —',
+        'tab_team'     => 'My Team',
+        'tab_partners' => 'Agent Partners',
+        'no_partners'  => 'No registered agent partners with active contracts for this operator. Set them up from the Tour Agent registration screen first.',
     ],
     'th' => [
         'page_title'   => 'ผูกบัญชีตัวแทน',
@@ -42,11 +45,21 @@ $labels = [
         'step2'        => '2. ไปที่หน้า <a href="index.php?page=line_users">Users</a> แล้วเปลี่ยน <strong>user_type</strong> เป็น <strong>agent</strong>',
         'step3'        => '3. กลับมาที่หน้านี้เพื่อผูกบัญชีกับผู้ใช้ iACC',
         'unbound'      => '— ยังไม่ผูก —',
+        'tab_team'     => 'ทีมของฉัน',
+        'tab_partners' => 'ตัวแทนพันธมิตร',
+        'no_partners'  => 'ยังไม่มีตัวแทนพันธมิตรที่มีสัญญาใช้งานอยู่ กรุณาลงทะเบียนตัวแทนในหน้า Tour Agent ก่อน',
     ],
 ];
 $t = $labels[$lang];
 
 $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] ?? '') === 'agent'));
+
+// #136: scope toggle — "team" (operator's own employees) vs "partners"
+// (employees of B2B partner agents registered with this operator).
+$scope = ($scope ?? 'team') === 'partners' ? 'partners' : 'team';
+$activeUsers = $scope === 'partners'
+    ? ($agentTenantUsers ?? [])
+    : ($iaccUsers ?? []);
 ?>
 <?php $currentNavPage = 'line_agent_bindings'; include __DIR__ . '/_nav.php'; ?>
 
@@ -57,12 +70,27 @@ $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] 
 <div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
 <?php unset($_SESSION['flash_error']); endif; ?>
 
+<div style="margin-bottom: 15px;">
+    <div class="btn-group" role="tablist">
+        <a href="index.php?page=line_agent_bindings&scope=team" class="btn btn-sm btn-<?= $scope === 'team' ? 'primary' : 'default' ?>">
+            <i class="fa fa-users"></i> <?= $t['tab_team'] ?>
+        </a>
+        <a href="index.php?page=line_agent_bindings&scope=partners" class="btn btn-sm btn-<?= $scope === 'partners' ? 'primary' : 'default' ?>">
+            <i class="fa fa-handshake-o"></i> <?= $t['tab_partners'] ?>
+        </a>
+    </div>
+</div>
+
 <div style="display:flex; gap:20px; flex-wrap:wrap;">
 
 <div style="flex:2; min-width:380px;">
     <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
         <h4 style="margin-top:0;"><i class="fa fa-link"></i> <?= $t['agent_users'] ?></h4>
         <p style="color:#666;"><?= $t['intro'] ?></p>
+
+        <?php if ($scope === 'partners' && empty($activeUsers)): ?>
+            <div class="alert alert-warning" style="margin:10px 0;"><?= $t['no_partners'] ?></div>
+        <?php endif; ?>
 
         <?php if (empty($agents)): ?>
             <p style="text-align:center; padding:30px 20px; color:#999;"><?= $t['no_agents'] ?></p>
@@ -94,6 +122,17 @@ $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] 
                                     <i class="fa fa-check"></i>
                                     <?= htmlspecialchars($a['linked_name'] ?: $a['linked_email'] ?: ('#' . $a['linked_user_id']), ENT_QUOTES, 'UTF-8') ?>
                                 </span>
+                                <?php
+                                // #136: when the bound user lives in an agent-partner tenant,
+                                // show the partner company name underneath so the admin can
+                                // see at a glance which agent this binding is attributed to.
+                                $partnerLabel = $isThai
+                                    ? ($a['partner_company_th'] ?? $a['partner_company_en'] ?? '')
+                                    : ($a['partner_company_en'] ?? $a['partner_company_th'] ?? '');
+                                ?>
+                                <?php if (!empty($partnerLabel)): ?>
+                                    <small class="text-muted" style="display:block;"><i class="fa fa-handshake-o"></i> <?= htmlspecialchars($partnerLabel, ENT_QUOTES, 'UTF-8') ?></small>
+                                <?php endif; ?>
                                 <?php if (!empty($a['linked_at'])): ?>
                                     <small class="text-muted" style="display:block;"><?= date('M d, Y', strtotime($a['linked_at'])) ?></small>
                                 <?php endif; ?>
@@ -105,11 +144,24 @@ $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] 
                             <form method="POST" action="index.php?page=line_agent_bind_save" style="display:inline-flex; gap:5px; align-items:center;">
                                 <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
                                 <input type="hidden" name="line_user_id" value="<?= (int)$a['id'] ?>">
-                                <select name="iacc_user_id" class="form-control input-sm" style="max-width:180px;">
+                                <select name="iacc_user_id" class="form-control input-sm" style="max-width:220px;">
                                     <option value=""><?= $t['select_user'] ?></option>
-                                    <?php foreach (($iaccUsers ?? []) as $u): ?>
+                                    <?php foreach (($activeUsers ?? []) as $u): ?>
+                                        <?php
+                                        // For partners scope, label with agent company so admins
+                                        // can disambiguate two reps with the same name from
+                                        // different partner agencies.
+                                        if ($scope === 'partners') {
+                                            $companyLabel = $isThai
+                                                ? ($u['agent_company_th'] ?? $u['agent_company_en'] ?? '')
+                                                : ($u['agent_company_en'] ?? $u['agent_company_th'] ?? '');
+                                            $optionLabel = ($u['name'] ?: $u['email']) . ' — ' . $companyLabel;
+                                        } else {
+                                            $optionLabel = ($u['name'] ?: $u['email']) . ' (lvl ' . (int)$u['level'] . ')';
+                                        }
+                                        ?>
                                         <option value="<?= (int)$u['id'] ?>" <?= ($a['linked_user_id'] ?? 0) == $u['id'] ? 'selected' : '' ?>>
-                                            <?= htmlspecialchars(($u['name'] ?: $u['email']) . ' (lvl ' . (int)$u['level'] . ')', ENT_QUOTES, 'UTF-8') ?>
+                                            <?= htmlspecialchars($optionLabel, ENT_QUOTES, 'UTF-8') ?>
                                         </option>
                                     <?php endforeach; ?>
                                 </select>


### PR DESCRIPTION
Closes [#136](https://github.com/psinthorn/iacc-php-mvc/issues/136). The deferred piece from v6.3 #132: extending the LINE bind UI so operators can bind LINE accounts to agent-partner employees (not just their own team), and auto-resolving `tour_bookings.agent_id` from those bindings.

## Summary

Operators can now bind a LINE OA account to **either**:

| Scope | Bound iACC user lives in | Booking attribution |
|---|---|---|
| **My Team** (existing) | Operator's own tenant | `agent_id = NULL` (sales rep) |
| **Agent Partners** (new) | Partner agent's tenant, registered with this operator via `tour_agent_profiles.company_ref_id` | `agent_id = <tour_agent_profiles.id>` (auto from binding) |

When a partner-tenant binding sends a booking, `ingestText` now resolves `agent_id` automatically — no manual entry, no `ตัวแทน:` typed code matching.

## Files

| File | Δ |
|---|---|
| `app/Models/LineOA.php` | +96 / −7 — `getEligibleAgentTenantUsers`, `resolveAgentIdFromBoundUser`, expanded `bindAgentToUser` auth check, relaxed `getAgentBindings` JOIN with partner company label, `getBoundUserDetails` returns `user_com_id` |
| `app/Controllers/LineAgentController.php` | +20 / −6 — `bindings()` passes both lists + `scope`; `ingestText` calls `resolveAgentIdFromBoundUser` and writes the resolved `agent_id` to the booking |
| `app/Views/line-oa/agent-bindings.php` | +52 / −6 — tab navigation, scope-aware dropdown labeling, partner company name on bound rows, TH/EN labels |

## Why no schema migration?

The linkage already exists in iACC's data model:
- `authorize.company_id` → tenant
- `tour_agent_profiles.company_id` = operator's tenant
- `tour_agent_profiles.company_ref_id` → agent's tenant (FK to `company.id`)

This PR only adds query + UI to use the existing relationships.

## Auth correctness

The expanded `bindAgentToUser` only allows binding to authorize users whose `company_id` is **either** the operator's own tenant **or** appears in `tour_agent_profiles.company_ref_id` for this operator (with `deleted_at IS NULL`). Cross-tenant random binds are still rejected. The `line_users` constraint is unchanged — LINE accounts always belong to the operator's OA.

The relaxed JOIN in `getAgentBindings` is *display only* — it doesn't grant access; bind time is still gated by `bindAgentToUser`.

## Verification

- All four files lint clean at PHP 7.4 inside `iacc_php` container
- All three new SQL queries executed against local DB without errors (zero result rows because local DB has no partner agents configured, but the SQL plan is valid)
- Diff: 3 files / +168 / −19

## Test plan (staging)

### My Team mode (regression check)
- [ ] Open `index.php?page=line_agent_bindings` (default `?scope=team`) — same UX as before
- [ ] Bind a LINE account to one of your operator-tenant users — works
- [ ] Send `จองทัวร์` template — booking_by shows the bound user's name; `agent_id = NULL` (since they're operator-team, not a partner)

### Agent Partners mode (new)
- [ ] Click the **Agent Partners** tab — dropdown now shows users from your registered partner agents, each labeled with their company name
- [ ] If you have no registered agent partners, see the bilingual notice
- [ ] Bind a LINE account to a partner-tenant user
- [ ] Send `จองทัวร์` from that LINE account — the booking row should have `agent_id` = the matching `tour_agent_profiles.id`
- [ ] Booking detail page shows the agent in the **Agent** field (was `-` before)

### Mixed scenarios
- [ ] Two partner agents have a user each with the same first name → dropdown disambiguates with company labels
- [ ] An agent partner with `contract_end` in the past → user does NOT appear in the dropdown
- [ ] Existing v6.3 bindings continue to display correctly (no migration; no data change)

## Out of scope

- Auto-suspend bindings when an agent contract expires (deferred — revisit if it becomes operational pain)
- Bulk-bind via CSV (defer until demand)
- Self-service binding from the agent portal (operator-side admin only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
