### PR TITLE
hotfix: fix tour_agent_profiles column references (production broken)

### DIFF
--- a/app/Models/TourBooking.php
+++ b/app/Models/TourBooking.php
@@ -162,10 +162,10 @@ class TourBooking extends BaseModel
         $sql = "SELECT b.*,
                        cust.name_en AS customer_name, cust.name_th AS customer_name_th,
                        agt.name_en AS agent_name, agt.name_th AS agent_name_th,
-                       tap.contact_email AS agent_email, tap.contact_mobile AS agent_mobile,
+                       tap.contact_email AS agent_email, tap.contact_phone AS agent_mobile,
                        CONCAT_WS(', ', tap.contact_line, tap.contact_whatsapp) AS agent_messengers,
                        srep.name_en AS sales_rep_name, srep.name_th AS sales_rep_name_th,
-                       srtap.contact_email AS sales_rep_email, srtap.contact_mobile AS sales_rep_mobile,
+                       srtap.contact_email AS sales_rep_email, srtap.contact_phone AS sales_rep_mobile,
                        CONCAT_WS(', ', srtap.contact_line, srtap.contact_whatsapp) AS sales_rep_messengers,
                        loc.name AS pickup_location_name, loc.location_type AS pickup_location_type
                 FROM tour_bookings b
@@ -532,7 +532,7 @@ class TourBooking extends BaseModel
     public function getAgentDropdown(int $comId): array
     {
         $sql = "SELECT c.id, c.name_en, c.name_th,
-                       tap.contact_email, tap.contact_mobile, tap.contact_line, tap.contact_whatsapp,
+                       tap.contact_email, tap.contact_phone AS contact_mobile, tap.contact_line, tap.contact_whatsapp,
                        tap.contact_messengers
                 FROM company c
                 INNER JOIN tour_agent_profiles tap ON c.id = tap.company_ref_id
@@ -663,7 +663,7 @@ class TourBooking extends BaseModel
     {
         $s = sql_escape(trim($term));
         $sql = "SELECT c.id, c.name_en, c.name_th,
-                       tap.contact_email, tap.contact_mobile,
+                       tap.contact_email, tap.contact_phone AS contact_mobile,
                        CONCAT_WS(', ', tap.contact_line, tap.contact_whatsapp) AS contact_messengers
                 FROM tour_agent_profiles tap
                 JOIN company c ON c.id = tap.company_ref_id
@@ -671,7 +671,7 @@ class TourBooking extends BaseModel
                   AND tap.deleted_at IS NULL
                   AND c.deleted_at IS NULL
                   AND (c.name_en LIKE '%$s%' OR c.name_th LIKE '%$s%'
-                       OR tap.contact_email LIKE '%$s%' OR tap.contact_mobile LIKE '%$s%')
+                       OR tap.contact_email LIKE '%$s%' OR tap.contact_phone LIKE '%$s%')
                 ORDER BY c.name_en
                 LIMIT " . intval($limit);
 


### PR DESCRIPTION
## Production hotfix — `Unknown column 'tap.contact_mobile' in 'field list'`

Production threw this error on `app/Models/TourBooking.php:544` when an admin opened a booking-related screen that calls `getAgentDropdown`. The same bug also affects `findBooking` (booking detail view) and `searchAgents` (agent search AJAX).

## Root cause

Pre-existing bug. The schema column on `tour_agent_profiles` is `contact_phone`, **not** `contact_mobile`. Four queries in `TourBooking.php` reference the non-existent column. None of them were hit during the v6.3 LINE-only flow we just shipped, but as soon as the operator started clicking into the booking detail / make pages on prod, the queries fired and threw.

```sql
SHOW COLUMNS FROM tour_agent_profiles LIKE 'contact_%';
-- contact_person, contact_email, contact_phone, contact_fax,
-- contact_line, contact_whatsapp, contact_telegram, contact_wechat, contact_messengers
-- (no contact_mobile)
```

## Change

Surgical: 5 substitutions in `TourBooking.php`. Source column renamed `contact_phone`; existing **column aliases preserved** (`agent_mobile`, `sales_rep_mobile`, `contact_mobile`) so no consumer code breaks.

| Method | Before | After |
|---|---|---|
| `findBooking` | `tap.contact_mobile AS agent_mobile` | `tap.contact_phone AS agent_mobile` |
| `findBooking` | `srtap.contact_mobile AS sales_rep_mobile` | `srtap.contact_phone AS sales_rep_mobile` |
| `getAgentDropdown` | `tap.contact_mobile` (no alias) | `tap.contact_phone AS contact_mobile` |
| `searchAgents` SELECT | `tap.contact_mobile` (no alias) | `tap.contact_phone AS contact_mobile` |
| `searchAgents` WHERE | `tap.contact_mobile LIKE` | `tap.contact_phone LIKE` |

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container
- `grep -c "tap.contact_mobile" TourBooking.php` → `0` (all source-side refs gone)
- The `contact_mobile` alias still appears in SELECT lists so any view code reading `$row['contact_mobile']` keeps working

## Why hotfix branch off main (not develop)

Prod is currently broken. Branching off main lets us deploy the fix directly without waiting on whatever else lands on develop. Will forward-merge `main` → `develop` after this lands so develop stays in sync.

## Test plan (post-deploy)

- [ ] Reproduce: open `index.php?page=tour_booking_make` (the booking-make page calls `getAgentDropdown`) — should now load without the "Unknown column" error
- [ ] Open booking detail for any existing booking — `findBooking` runs without error
- [ ] Use the agent search AJAX (`tour_booking_agent_search`) — returns results without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
