### PR TITLE
feat(v6.4): #133 Phase 1 — LineTemplateRenderer + plain text reply customization

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -156,17 +156,22 @@ class LineAgentController extends BaseController
         $iaccUserId   = $line->getBoundIaccUserId($companyId, $lineUserIdStr);
         $isBoundAgent = !empty($iaccUserId);
 
-        // Match the tour name within the tenant's tours
+        // Match the tour name within the tenant's tours.
+        // The "not found" / "ambiguous" replies go through LineTemplateRenderer
+        // (#133 Phase 1) so admins can customize the wording per tenant via
+        // the existing template-edit.php page. Hardcoded defaults stay as
+        // the fallback when no per-tenant override exists.
         $tourMatch = self::matchTour($companyId, $fields['tour_name']);
         if ($tourMatch['status'] === 'none') {
+            $msg = \App\Services\LineTemplateRenderer::renderText(
+                $companyId, 'agent.tour_not_found', $lang,
+                ['tour_name' => $fields['tour_name']]
+            );
             return [
                 'handled'        => true,
                 'reason'         => 'tour_not_found',
                 'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText(($lang === 'th'
-                    ? 'ไม่พบทัวร์ที่ตรงกับ "%s" ในระบบ'
-                    : 'No tour matching "%s" found in your system.'),
-                    [$fields['tour_name']])],
+                'reply_messages' => [['type' => 'text', 'text' => $msg]],
             ];
         }
         if ($tourMatch['status'] === 'multiple') {
@@ -174,14 +179,15 @@ class LineAgentController extends BaseController
             foreach ($tourMatch['candidates'] as $i => $c) {
                 $list .= ($i + 1) . ') ' . $c['name'] . "\n";
             }
+            $msg = \App\Services\LineTemplateRenderer::renderText(
+                $companyId, 'agent.tour_ambiguous', $lang,
+                ['candidates' => $list]
+            );
             return [
                 'handled'        => true,
                 'reason'         => 'tour_ambiguous',
                 'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText(($lang === 'th'
-                    ? "พบทัวร์หลายรายการที่ตรงกัน:\n%sกรุณาส่งใหม่พร้อมระบุชื่อให้ชัดเจนยิ่งขึ้น"
-                    : "Multiple tours matched:\n%sPlease re-send with a more specific name."),
-                    [$list])],
+                'reply_messages' => [['type' => 'text', 'text' => $msg]],
             ];
         }
 
@@ -327,13 +333,14 @@ class LineAgentController extends BaseController
         }
 
         if ($bookingId <= 0) {
+            $msg = \App\Services\LineTemplateRenderer::renderText(
+                $companyId, 'agent.write_failed', $lang
+            );
             return [
                 'handled'        => true,
                 'reason'         => 'write_failed',
                 'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText($lang === 'th'
-                    ? 'เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ'
-                    : 'Could not save the booking. Please contact your admin.')],
+                'reply_messages' => [['type' => 'text', 'text' => $msg]],
             ];
         }
 

--- a/app/Services/LineTemplateRenderer.php
+++ b/app/Services/LineTemplateRenderer.php
@@ -1,0 +1,165 @@
+<?php
+namespace App\Services;
+
+/**
+ * LineTemplateRenderer — v6.4 #133
+ *
+ * Per-tenant template rendering for LINE OA reply text. Reads from the
+ * `line_message_templates` table (created by v6.2 LINE OA Rich Messaging,
+ * catch-up migration in v6.4); falls back to hardcoded defaults when a
+ * template is missing or fails to render.
+ *
+ * v1 scope (this PR) — plain-text replies only:
+ *   - agent.tour_not_found  → "ไม่พบทัวร์ที่ตรงกับ ..."
+ *   - agent.tour_ambiguous  → "พบทัวร์หลายรายการที่ตรงกัน: ..."
+ *   - agent.write_failed    → "เกิดข้อผิดพลาดในการบันทึก ..."
+ *   - legacy.book_redirect  → "กรุณาใช้แบบฟอร์มการจองใหม่ ..."
+ *
+ * Future scope (Phase 2): the success/error Flex bubbles. They have
+ * conditional rows (email line only when email present, etc.) that
+ * require a richer template format than plain string substitution.
+ *
+ * Placeholder syntax: `{{name}}` — Mustache-style, friendly for admin
+ * editors. Substitution is a simple str_replace pre-render. Missing
+ * placeholders are left as `{{name}}` literally (visible to user, makes
+ * misconfiguration loud rather than silent).
+ *
+ * Usage:
+ *
+ *   $text = LineTemplateRenderer::renderText(
+ *       $companyId,
+ *       'agent.tour_not_found',
+ *       'th',
+ *       ['tour_name' => 'SM-EN-01-AT']
+ *   );
+ *
+ * Lookup order:
+ *   1. line_message_templates row (per-tenant, by name)
+ *   2. Hardcoded default in self::DEFAULTS (this file)
+ *
+ * The "lazy seed" pattern (insert the default into the tenant's table on
+ * first miss) is intentionally NOT done here — it would create a row that
+ * looks like an admin override even though the admin never edited it. The
+ * existing template-edit.php page lets admins create/edit per-tenant
+ * customizations explicitly when they want to.
+ */
+class LineTemplateRenderer
+{
+    /**
+     * Hardcoded defaults — single source of truth when no per-tenant
+     * customization exists. Each key is the canonical template name; each
+     * value carries the bilingual TH+EN content and a sample list of
+     * placeholder names (informational, used by the editor's help panel).
+     */
+    private const DEFAULTS = [
+        'agent.tour_not_found' => [
+            'message_type' => 'text',
+            'th'           => 'ไม่พบทัวร์ที่ตรงกับ "{{tour_name}}" ในระบบ',
+            'en'           => 'No tour matching "{{tour_name}}" found in your system.',
+            'placeholders' => ['tour_name'],
+        ],
+        'agent.tour_ambiguous' => [
+            'message_type' => 'text',
+            'th'           => "พบทัวร์หลายรายการที่ตรงกัน:\n{{candidates}}กรุณาส่งใหม่พร้อมระบุชื่อให้ชัดเจนยิ่งขึ้น",
+            'en'           => "Multiple tours matched:\n{{candidates}}Please re-send with a more specific name.",
+            'placeholders' => ['candidates'],
+        ],
+        'agent.write_failed' => [
+            'message_type' => 'text',
+            'th'           => 'เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ',
+            'en'           => 'Could not save the booking. Please contact your admin.',
+            'placeholders' => [],
+        ],
+        'legacy.book_redirect' => [
+            'message_type' => 'text',
+            'th'           => "กรุณาใช้แบบฟอร์มการจองใหม่ — พิมพ์ \"จองทัวร์\" พร้อมรายละเอียด เช่น:\n\nจองทัวร์\nทัวร์: <ชื่อทัวร์>\nวันที่: {{sample_date}}\nผู้ใหญ่: <จำนวน>\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>",
+            'en'           => "Please use the new booking template — start your message with \"book tour\" and include the tour details, e.g.:\n\nbook tour\ntour: <tour name>\ndate: {{sample_date}}\nadults: <count>\ncustomer: <name>\nmobile: <phone>",
+            'placeholders' => ['sample_date'],
+        ],
+    ];
+
+    /**
+     * Render a plain-text template for the given tenant + name + language,
+     * substituting `{{placeholders}}`.
+     *
+     * Returns the rendered string. Never throws — failures are logged and
+     * the hardcoded default is rendered instead, so the customer-facing
+     * reply path is never broken by a misconfigured template.
+     */
+    public static function renderText(int $companyId, string $name, string $lang, array $vars = []): string
+    {
+        $lang = ($lang === 'th') ? 'th' : 'en';
+        $template = self::lookup($companyId, $name, $lang);
+
+        // Substitute placeholders. Missing keys are intentionally left as
+        // literal `{{name}}` so misconfiguration is loud rather than silent.
+        $rendered = $template;
+        foreach ($vars as $k => $v) {
+            $rendered = str_replace('{{' . $k . '}}', (string)$v, $rendered);
+        }
+        return $rendered;
+    }
+
+    /**
+     * Look up the per-tenant template content for one language. Falls
+     * back to the hardcoded default in self::DEFAULTS when:
+     *   - The line_message_templates row is missing (most common case)
+     *   - The row's content for the requested language is empty/null
+     *   - Any DB error fires (logged, then fallback)
+     */
+    private static function lookup(int $companyId, string $name, string $lang): string
+    {
+        $default = self::DEFAULTS[$name] ?? null;
+        $defaultContent = $default[$lang] ?? '';
+
+        // No DB connection available (e.g. unit-testing the renderer in
+        // isolation) — short-circuit to defaults.
+        global $db;
+        if (!isset($db) || !is_object($db) || !isset($db->conn)) {
+            return $defaultContent;
+        }
+
+        try {
+            $stmt = $db->conn->prepare(
+                "SELECT content_th, content_en FROM line_message_templates
+                 WHERE company_id = ? AND name = ?
+                   AND is_active = 1
+                   AND deleted_at IS NULL
+                 ORDER BY id DESC
+                 LIMIT 1"
+            );
+            $stmt->bind_param('is', $companyId, $name);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            if ($row) {
+                $col = ($lang === 'th') ? 'content_th' : 'content_en';
+                $val = trim((string)($row[$col] ?? ''));
+                if ($val !== '') return $val;
+            }
+        } catch (\Throwable $e) {
+            error_log('LineTemplateRenderer::lookup failed for company ' . $companyId
+                . ' name ' . $name . ' — falling back to default: ' . $e->getMessage());
+        }
+
+        return $defaultContent;
+    }
+
+    /**
+     * List the canonical template names so the editor UI (in v6.4 #133
+     * Phase 2) can show admins what's available to customize. Read by
+     * the templates index page if/when we wire it up.
+     */
+    public static function listKnownTemplates(): array
+    {
+        $out = [];
+        foreach (self::DEFAULTS as $name => $meta) {
+            $out[$name] = [
+                'message_type' => $meta['message_type'],
+                'placeholders' => $meta['placeholders'] ?? [],
+            ];
+        }
+        return $out;
+    }
+}

--- a/database/migrations/2026_05_07_v6_4_133_line_message_templates_catchup.sql
+++ b/database/migrations/2026_05_07_v6_4_133_line_message_templates_catchup.sql
@@ -1,0 +1,55 @@
+-- Migration: 2026_05_07_v6_4_133_line_message_templates_catchup.sql
+-- v6.4 #133 — Catch-up migration for line_message_templates
+--
+-- The v6.2 LINE OA Rich Messaging code references this table
+-- (App\Models\LineMessaging::getTemplates etc.) but no migration file
+-- existed in database/migrations/ to create it. Production DBs already
+-- have it (created out-of-band during the v6.2 deploy); this migration
+-- is a CREATE TABLE IF NOT EXISTS so:
+--   * Local dev DBs get the table for the first time
+--   * New tenant DBs get it on next provision
+--   * Production is unchanged (table already exists, statement is no-op)
+--
+-- The schema mirrors what's currently on production staging
+-- (f2coth_dev) per phpMyAdmin's SHOW COLUMNS output. The enum on
+-- template_type intentionally only includes values we control here;
+-- production may have additional values from the v6.2 deploy and they
+-- are preserved (this migration won't run there).
+--
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+
+CREATE TABLE IF NOT EXISTS `line_message_templates` (
+    `id`             INT(11) NOT NULL AUTO_INCREMENT,
+    `company_id`     INT(11) NOT NULL,
+    `name`           VARCHAR(150) NOT NULL,
+    -- Matches the production enum verified on f2coth_dev 2026-05-07.
+    -- Agent-flow templates are identified by `name` prefix (e.g.
+    -- 'agent.booking_confirmed') with template_type='custom' — see
+    -- LineTemplateRenderer. Adding new enum values here would diverge
+    -- from prod and force a schema change at next deploy.
+    `template_type`  ENUM(
+                        'tour_package',
+                        'quotation',
+                        'booking_confirm',
+                        'payment_reminder',
+                        'voucher',
+                        'custom'
+                     ) DEFAULT 'custom',
+    `message_type`   ENUM('text','flex') DEFAULT 'flex',
+    `alt_text`       VARCHAR(400) DEFAULT NULL,
+    `content_th`     TEXT DEFAULT NULL,
+    `content_en`     TEXT DEFAULT NULL,
+    `variables_json` TEXT DEFAULT NULL
+                     COMMENT 'JSON list of placeholder definitions for the editor UI',
+    `is_active`      TINYINT(1) DEFAULT 1,
+    `created_by`     INT(11) DEFAULT NULL,
+    `created_at`     DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`     DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`     DATETIME DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_lmt_company`        (`company_id`),
+    KEY `idx_lmt_template_type`  (`template_type`),
+    KEY `idx_lmt_is_active`      (`is_active`),
+    KEY `idx_lmt_company_name`   (`company_id`, `name`)
+        COMMENT 'Used by LineTemplateRenderer for per-tenant lookups by template name'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -325,9 +325,14 @@ function handleBookingCommand(string $replyToken, int $companyId, int $dbUserId,
     // ones from this entry point.
     $lineUser    = $model->getLineUserById($dbUserId);
     $lang        = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', $bookingText) ? 'th' : 'en';
-    $redirectMsg = $lang === 'th'
-        ? "กรุณาใช้แบบฟอร์มการจองใหม่ — พิมพ์ \"จองทัวร์\" พร้อมรายละเอียด เช่น:\n\nจองทัวร์\nทัวร์: <ชื่อทัวร์>\nวันที่: " . ($_POST['date'] ?? date('Y-m-d', strtotime('+7 days'))) . "\nผู้ใหญ่: <จำนวน>\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>"
-        : "Please use the new booking template — start your message with \"book tour\" and include the tour details, e.g.:\n\nbook tour\ntour: <tour name>\ndate: " . date('Y-m-d', strtotime('+7 days')) . "\nadults: <count>\ncustomer: <name>\nmobile: <phone>";
+    // Renderer routes through line_message_templates (#133) so admins can
+    // customize the wording per tenant — falls back to a hardcoded default
+    // when no override exists. {{sample_date}} suggests a realistic future
+    // travel date so the user isn't tempted to copy-paste a stale value.
+    $redirectMsg = \App\Services\LineTemplateRenderer::renderText(
+        $companyId, 'legacy.book_redirect', $lang,
+        ['sample_date' => date('Y-m-d', strtotime('+7 days'))]
+    );
 
     $service->replyText($replyToken, $redirectMsg);
     $model->logMessage($companyId, $dbUserId, 'outbound', 'text', null, null, '[v6.6 #134 redirect: legacy book→template] ' . substr($redirectMsg, 0, 80));


### PR DESCRIPTION
Closes [#133](https://github.com/psinthorn/iacc-php-mvc/issues/133) Phase 1. Per-tenant brand-voice customization for the LINE OA agent flow's plain-text replies. Admins can now override the wording via the existing v6.2 templates UI without a code deploy.

## Summary

This PR adds a thin templating layer:

- **Catch-up migration** for `line_message_templates` (table existed on prod from v6.2 deploy, no migration in repo — fixes for local dev + new tenants)
- **`LineTemplateRenderer` service** — looks up per-tenant content by `company_id + name`, substitutes `{{placeholders}}`, falls back to hardcoded defaults when no override exists
- **4 plain-text replies wired** through the renderer (Flex bubbles deferred to Phase 2)

The existing [template-edit.php](app/Views/line-oa/template-edit.php) page already supports `content_th` / `content_en` / `variables_json` editing — so admins can customize per-tenant **today** with no new admin UI shipped this PR.

## Templates wired in this PR

| Name | Where | Fallback default (TH) |
|---|---|---|
| `agent.tour_not_found` | `LineAgentController::ingestText` | `ไม่พบทัวร์ที่ตรงกับ "{{tour_name}}" ในระบบ` |
| `agent.tour_ambiguous` | `LineAgentController::ingestText` | `พบทัวร์หลายรายการที่ตรงกัน:\n{{candidates}}กรุณาส่งใหม่...` |
| `agent.write_failed` | `LineAgentController::ingestText` | `เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ` |
| `legacy.book_redirect` | `line-webhook.php` (deprecated v6.2 customer flow) | `กรุณาใช้แบบฟอร์มการจองใหม่ — พิมพ์ "จองทัวร์"...{{sample_date}}...` |

EN equivalents stored alongside; runtime picks based on incoming message language (existing `AgentBookingParser::detectLang`).

## Architecture

### Lookup order (per call)
1. `line_message_templates` row matching `company_id + name + is_active=1 + deleted_at IS NULL`
2. Hardcoded default in `LineTemplateRenderer::DEFAULTS`

### Why no lazy seeding (auto-insert defaults on first miss)?
Tempting but wrong UX: it creates rows that look like admin overrides even though the admin never edited them. Admins should explicitly create overrides when they want to customize. Without lazy seeding, the templates UI lists what THIS admin has changed — clean.

### Why not template the Flex bubbles?
The success / error Flex have conditional rows (email line only if email present, hotel line only if hotel present, etc.). Plain `{{placeholder}}` substitution doesn't handle conditionals. Phase 2 will add a sub-template system or convention for this. For now the bubbles stay hardcoded — Phase 1 ships the most-customized text first.

### Naming convention: `agent.*` and `legacy.*`
Identifies templates by `name` field (existing `varchar(150)`) with prefixes — sidesteps the need to extend the `template_type` enum. Forward-compatible: a future `template_category` column can formalize the namespace.

## Files

| File | Δ |
|---|---|
| `database/migrations/2026_05_07_v6_4_133_line_message_templates_catchup.sql` (new) | +55 — `CREATE TABLE IF NOT EXISTS` mirroring prod schema |
| `app/Services/LineTemplateRenderer.php` (new) | +147 — renderer + hardcoded defaults |
| `app/Controllers/LineAgentController.php` | +18 / −14 — replace 3 inline strings with renderer calls |
| `line-webhook.php` | +9 / −5 — replace inline redirect string with renderer call |

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container for all 4 files
- Migration ran cleanly on local DB; resulting schema matches prod (`SHOW COLUMNS` parity verified)
- Renderer unit-tested locally without DB connection — all 4 templates render placeholder substitutions correctly and fall back to defaults

## Test plan (staging)

### Default behavior (no overrides)
- [ ] Run migration on staging phpMyAdmin (idempotent — should be a no-op since table exists)
- [ ] Send a `จองทัวร์` template with a non-existent tour name → reply matches the existing default ("ไม่พบทัวร์ที่ตรงกับ ... ในระบบ")
- [ ] Send `book 2026-06-15 14:00` (legacy bare command) → reply is the redirect message with `{{sample_date}}` substituted to today+7

### Per-tenant override
- [ ] As admin, open `index.php?page=line_template_edit` (template create page)
- [ ] Create a template with `name='agent.tour_not_found'`, `content_th='ขออภัย ไม่พบทัวร์ตามที่ระบุ — {{tour_name}}'`, `content_en='Sorry — no tour found matching {{tour_name}}.'`, `is_active=1`
- [ ] Send the same `จองทัวร์` with non-existent tour again → reply now uses your custom text with placeholder substituted
- [ ] Soft-delete the template row → reply falls back to the default again

### Multi-tenant isolation
- [ ] Create a `agent.tour_not_found` override on tenant A → tenant B's bookings still get the default

## Out of scope (Phase 2)

- Template the success / error Flex bubbles (conditional row logic)
- Editor UI improvements: placeholder help panel, validation that required `{{vars}}` are present, live Flex preview, lazy-seed defaults on first lookup-miss
- Self-service template versioning / undo
- Per-tier feature gate (e.g., template editing locked on free plan)

## Migration impact

Production runs `CREATE TABLE IF NOT EXISTS` — table already exists, so it's a no-op. Local dev + new tenants get the table on next migration run. **Safe to re-run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
