### PR TITLE
fix(v6.6): #135 follow-up — model.is_customer_bookable + expanded prefill

### DIFF
--- a/app/Services/LineTourCatalog.php
+++ b/app/Services/LineTourCatalog.php
@@ -117,11 +117,36 @@ class LineTourCatalog
         $sampleDate = date('Y-m-d', strtotime('+7 days'));
         $tourName   = $tour['model_name'];
 
+        // Expanded in the v6.6 #135 follow-up to include all parser-supported
+        // optional fields (hotel, room, messenger, notes) so users discover
+        // them rather than missing pickup-relevant info on first send.
         $text = $isThai
-            ? "เริ่มการจองทัวร์ \"{$tourName}\"\nกรุณาส่งข้อความตามรูปแบบด้านล่าง พร้อมกรอกข้อมูลให้ครบ:\n\n"
-              . "จองทัวร์\nทัวร์: {$tourName}\nวันที่: {$sampleDate}\nผู้ใหญ่: <จำนวน>\nเด็ก: 0\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>\nอีเมล: <อีเมล (ถ้ามี)>"
-            : "Starting booking for \"{$tourName}\"\nPlease send back the template below with the remaining details filled in:\n\n"
-              . "book tour\ntour: {$tourName}\ndate: {$sampleDate}\nadults: <count>\nchildren: 0\ncustomer: <name>\nmobile: <phone>\nemail: <email (optional)>";
+            ? "เริ่มการจองทัวร์ \"{$tourName}\"\nกรุณาส่งข้อความตามรูปแบบด้านล่าง พร้อมกรอกข้อมูลให้ครบ (ฟิลด์ที่มี * เป็นข้อมูลที่จำเป็น):\n\n"
+              . "จองทัวร์\n"
+              . "ทัวร์: {$tourName}\n"
+              . "วันที่: {$sampleDate} *\n"
+              . "ผู้ใหญ่: <จำนวน> *\n"
+              . "เด็ก: 0\n"
+              . "ลูกค้า: <ชื่อ> *\n"
+              . "มือถือ: <เบอร์> *\n"
+              . "อีเมล: <อีเมล (ถ้ามี)>\n"
+              . "เมสเซนเจอร์: <line:id หรือ @page (ถ้ามี)>\n"
+              . "ที่พัก: <ชื่อโรงแรม/ที่พัก (ถ้ามี)>\n"
+              . "หมายเลขห้อง: <เลขห้อง (ถ้ามี)>\n"
+              . "หมายเหตุ: <รายละเอียดเพิ่มเติม (ถ้ามี)>"
+            : "Starting booking for \"{$tourName}\"\nPlease send back the template below with the remaining details filled in (* = required):\n\n"
+              . "book tour\n"
+              . "tour: {$tourName}\n"
+              . "date: {$sampleDate} *\n"
+              . "adults: <count> *\n"
+              . "children: 0\n"
+              . "customer: <name> *\n"
+              . "mobile: <phone> *\n"
+              . "email: <email (optional)>\n"
+              . "messenger: <line:id or @page (optional)>\n"
+              . "accommodation: <hotel/villa name (optional)>\n"
+              . "room: <room number (optional)>\n"
+              . "notes: <extra details (optional)>";
 
         return ['type' => 'text', 'text' => $text];
     }
@@ -131,8 +156,14 @@ class LineTourCatalog
     // ============================================================
 
     /**
-     * Fetch active tours for the operator. Joins type for the category
-     * label. Tenancy enforced via company_id.
+     * Fetch active, customer-bookable tours for the operator. Joins type
+     * for the category label. Tenancy enforced via company_id.
+     *
+     * The is_customer_bookable filter (added in the v6.6 #135 follow-up)
+     * lets operators hide non-tour rows like entrance fees from the
+     * customer-facing catalog while keeping them otherwise active for
+     * pricing/reporting. Default for new and existing rows is 1
+     * (visible) — operators flip specific rows to 0 to hide them.
      */
     private static function fetchActiveTours(int $companyId, int $limit): array
     {
@@ -145,6 +176,7 @@ class LineTourCatalog
              WHERE m.company_id = ?
                AND m.deleted_at IS NULL
                AND m.is_active = 1
+               AND m.is_customer_bookable = 1
              ORDER BY t.name ASC, m.model_name ASC
              LIMIT ?"
         );

--- a/database/migrations/2026_05_07_v6_6_135_model_is_customer_bookable.sql
+++ b/database/migrations/2026_05_07_v6_6_135_model_is_customer_bookable.sql
@@ -1,0 +1,46 @@
+-- Migration: 2026_05_07_v6_6_135_model_is_customer_bookable.sql
+-- v6.6 #135 follow-up — add is_customer_bookable flag to model
+--
+-- Carousel discovery (#135) shows every active model row, including
+-- non-tour entries like entrance fees that operators don't want
+-- customers booking directly. This flag lets the operator hide
+-- specific models from the LINE OA catalog while keeping them
+-- otherwise active for internal pricing/reporting.
+--
+-- Default = 1 so existing tours stay visible; admin flips specific
+-- rows to 0 for entrance fees and other internal-only models.
+--
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+-- Idempotent via stored-procedure column-existence check
+
+DROP PROCEDURE IF EXISTS _migrate_v66_135_bookable;
+DELIMITER $$
+CREATE PROCEDURE _migrate_v66_135_bookable()
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'model'
+          AND COLUMN_NAME  = 'is_customer_bookable'
+    ) THEN
+        ALTER TABLE `model`
+            ADD COLUMN `is_customer_bookable` TINYINT(1) NOT NULL DEFAULT 1
+            COMMENT 'v6.6 #135 — show this model in LINE OA customer-facing catalog (1=yes, 0=hidden, e.g. entrance fees)';
+    END IF;
+
+    -- Index to keep the LineTourCatalog query fast even on tenants with
+    -- many models. Composite (company_id, is_active, is_customer_bookable)
+    -- matches the WHERE clause exactly.
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'model'
+          AND INDEX_NAME   = 'idx_model_company_active_bookable'
+    ) THEN
+        CREATE INDEX `idx_model_company_active_bookable`
+            ON `model` (`company_id`, `is_active`, `is_customer_bookable`);
+    END IF;
+END$$
+DELIMITER ;
+CALL _migrate_v66_135_bookable();
+DROP PROCEDURE IF EXISTS _migrate_v66_135_bookable;


### PR DESCRIPTION
Two issues caught during staging test of the v6.6 #135 carousel rollout, both fixed in this PR.

## Issue 1: Carousel shows non-tour models

Operators saw "Entrance fee ค่าใช้จ่ายหน้าท่า" and "Entrance fee ค่าขึ้นเกาะ" in the customer-facing tour catalog. These are `model` rows used internally for pricing, not tours customers should book directly.

**Fix:** New `model.is_customer_bookable` flag — was deferred from the original #135 spec. Default `1` so existing tours stay visible.

## Issue 2: Pre-filled template missing optional fields

The Book button's pre-filled template only included tour, date, adults, children, customer, mobile, email — missing the parser-supported optional fields (hotel, room, messenger, notes) that operators want customers to provide for pickup logistics.

**Fix:** Expanded the prefill text to include all parser fields with `*` markers on required ones.

## Files

| File | Δ |
|---|---|
| `database/migrations/2026_05_07_v6_6_135_model_is_customer_bookable.sql` (new) | +47 — idempotent stored-proc adds column + composite index |
| `app/Services/LineTourCatalog.php` | +25 / −10 — filter on is_customer_bookable + expanded prefill template |

## Schema change

```sql
ALTER TABLE `model`
    ADD COLUMN `is_customer_bookable` TINYINT(1) NOT NULL DEFAULT 1
    COMMENT 'v6.6 #135 — show this model in LINE OA customer-facing catalog (1=yes, 0=hidden, e.g. entrance fees)';

CREATE INDEX `idx_model_company_active_bookable`
    ON `model` (`company_id`, `is_active`, `is_customer_bookable`);
```

Wrapped in stored-proc column-existence check — safe to re-run, safe to deploy without coordinating file deploy and migration order.

## Default = 1 (visible)

Every existing model row stays visible in the carousel by default. Operators flip specific rows to 0 only when they want to hide them. **No operator action is required** unless they have non-tour models to hide.

## Operator workflow (until UI checkbox ships)

After running the migration, hide entrance fees / non-tour models via phpMyAdmin:

```sql
UPDATE model SET is_customer_bookable = 0
WHERE company_id = <YOUR_COMPANY_ID>
  AND model_name IN ('SM-EN-01-AT', 'SM-EN-01-TY');
-- adjust the IN list per tenant
```

A follow-up PR will add a "Show in customer LINE catalog" checkbox to the model admin page so operators don't need DB access.

## Pre-filled template — before / after

**Before** (TH):
```
จองทัวร์
ทัวร์: <tour>
วันที่: <date>
ผู้ใหญ่: <count>
เด็ก: 0
ลูกค้า: <name>
มือถือ: <phone>
อีเมล: <email (optional)>
```

**After** (TH):
```
จองทัวร์
ทัวร์: <tour>
วันที่: <date> *
ผู้ใหญ่: <count> *
เด็ก: 0
ลูกค้า: <name> *
มือถือ: <phone> *
อีเมล: <email (optional)>
เมสเซนเจอร์: <line:id or @page (optional)>
ที่พัก: <hotel/villa name (optional)>
หมายเลขห้อง: <room number (optional)>
หมายเหตุ: <extra details (optional)>
```

EN version mirrors the same structure.

## Verification

- Migration ran twice locally without error (idempotent ✅)
- Carousel: 9 bubbles → 8 after hiding one model row ✅
- Prefill (TH): contains `ที่พัก`, `หมายเลขห้อง`, `เมสเซนเจอร์` ✅
- Prefill (EN): contains `accommodation:`, `room:` ✅
- `php -l` clean at PHP 7.4

## Test plan (staging)

- [ ] Run migration on staging phpMyAdmin (idempotent) — verify column + index present
- [ ] Send `ดูทัวร์` — carousel should show same tours as before (default `is_customer_bookable=1`)
- [ ] Run the SQL to hide entrance fees (see Operator workflow above)
- [ ] Send `ดูทัวร์` again — entrance fees no longer in carousel
- [ ] Tap Book on any remaining tour — pre-filled template now includes hotel, room, messenger, notes lines
- [ ] Send back the completed template (with `ที่พัก:` filled in) → booking row's `pickup_hotel` populated as before

## Out of scope (deferred)

- UI checkbox in the model admin page for `is_customer_bookable` — separate PR
- Templating the prefill via `LineTemplateRenderer` (#133 namespace) so admins can customize per tenant — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
