### PR TITLE
feat(v6.6): #135 — UI checkbox for is_customer_bookable on model admin

### DIFF
--- a/app/Controllers/ModelController.php
+++ b/app/Controllers/ModelController.php
@@ -82,25 +82,31 @@ class ModelController extends BaseController
         $price     = floatval($_REQUEST['price'] ?? 0);
         $des       = $this->inputStr('des', '');
         $companyId = $this->getCompanyId();
+        // v6.6 #135 follow-up — LINE catalog visibility toggle. HTML
+        // unchecked checkboxes don't submit, so absence means "uncheck"
+        // (i.e. hide from carousel). New rows default to visible.
+        $isCustomerBookable = isset($_POST['is_customer_bookable']) ? 1 : 0;
 
         switch ($method) {
             case 'A': // Add
                 $this->model->create([
-                    'company_id' => $companyId,
-                    'type_id'    => $typeId,
-                    'brand_id'   => $brandId,
-                    'model_name' => $modelName,
-                    'des'        => $des,
-                    'price'      => $price,
+                    'company_id'           => $companyId,
+                    'type_id'              => $typeId,
+                    'brand_id'             => $brandId,
+                    'model_name'           => $modelName,
+                    'des'                  => $des,
+                    'price'                => $price,
+                    'is_customer_bookable' => $isCustomerBookable,
                 ]);
                 break;
 
             case 'E': // Edit
                 if ($id > 0) {
                     $data = [
-                        'model_name' => $modelName,
-                        'des'        => $des,
-                        'price'      => $price,
+                        'model_name'           => $modelName,
+                        'des'                  => $des,
+                        'price'                => $price,
+                        'is_customer_bookable' => $isCustomerBookable,
                     ];
                     if ($typeId > 0)  $data['type_id']  = $typeId;
                     if ($brandId > 0) $data['brand_id'] = $brandId;

--- a/app/Views/model/list.php
+++ b/app/Views/model/list.php
@@ -174,6 +174,32 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
                        placeholder="Enter description..." style="min-height:100px;"><?=htmlspecialchars($edit_data['des'] ?? '')?></textarea>
             </div>
         </div>
+        <?php
+            // v6.6 #135 follow-up — LINE catalog visibility toggle.
+            // Defaults to 1 (visible) for new rows; admins uncheck to hide
+            // non-tour models like entrance fees from the customer-facing
+            // carousel triggered by "ดูทัวร์" / "show tours".
+            $_isThai = ($_SESSION['lang'] ?? '0') === '1';
+            $_isCustomerBookable = (int)($edit_data['is_customer_bookable'] ?? 1);
+        ?>
+        <div class="form-row">
+            <div class="form-group" style="width:100%;">
+                <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                    <input type="checkbox" name="is_customer_bookable" value="1"
+                           <?= $_isCustomerBookable === 1 ? 'checked' : '' ?>
+                           style="width:auto; margin:0;">
+                    <span style="font-weight:500;">
+                        <i class="fa fa-line-chart" style="color:#06C755;"></i>
+                        <?= $_isThai ? 'แสดงในรายการทัวร์ LINE OA' : 'Show in LINE OA catalog' ?>
+                    </span>
+                </label>
+                <small class="text-muted" style="display:block; margin-top:4px; margin-left:24px;">
+                    <?= $_isThai
+                        ? 'ติ๊กเพื่อให้ทัวร์นี้แสดงในรายการที่ลูกค้าเห็นเมื่อพิมพ์ "ดูทัวร์" ผ่าน LINE OA — ยกเลิกถ้าเป็นรายการที่ไม่ใช่ทัวร์ (เช่น ค่าเข้าหน้าท่า)'
+                        : 'Check to include this row in the customer-facing carousel triggered by "show tours" / "ดูทัวร์". Uncheck for non-tour items (e.g. entrance fees).' ?>
+                </small>
+            </div>
+        </div>
         <div class="form-actions">
             <input type="hidden" name="method" value="<?=$edit_data ? 'E' : 'A'?>">
             <input type="hidden" name="page" value="mo_list">


### PR DESCRIPTION
Follow-up to [#145](https://github.com/psinthorn/iacc-php-mvc/pull/145). Adds a "Show in LINE OA catalog" checkbox to the model admin form so operators can toggle `is_customer_bookable` without running SQL via phpMyAdmin.

## Why

#145 shipped the `model.is_customer_bookable` column + the carousel filter, but admins had no in-app way to flip it. They had to write `UPDATE model SET is_customer_bookable = 0 WHERE ...` in phpMyAdmin every time they wanted to hide a non-tour model like an entrance fee. Bad SaaS UX, especially for non-technical operators.

## Change

| Layer | What |
|---|---|
| `app/Views/model/list.php` | New form-row with checkbox + bilingual label + help text linking to the `ดูทัวร์` / `show tours` carousel trigger so the meaning is clear in context |
| `app/Controllers/ModelController::store` | Read `is_customer_bookable` from POST. HTML unchecked checkboxes don't submit, so absence means "hide from carousel" (`=0`). Wired into Add and Edit branches |

No schema changes — column already shipped in #145. No new model methods — `BaseModel::create`/`update` accept arbitrary column→value maps.

## UX

```
[ ✓ ]  📈 Show in LINE OA catalog
       Check to include this row in the customer-facing carousel
       triggered by "show tours" / "ดูทัวร์". Uncheck for non-tour
       items (e.g. entrance fees).
```

Bilingual TH/EN per CLAUDE.md. Default checked for new rows so the column's `DEFAULT 1` semantic is preserved end-to-end.

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container for both files
- Diff: 2 files / +41 / −9

## Test plan (staging)

- [ ] Open `index.php?page=mo_list&new=1` → form shows the new checkbox, **checked by default**
- [ ] Create a new model with checkbox checked → row written with `is_customer_bookable=1`
- [ ] Send `ดูทัวร์` via LINE → new model appears in carousel
- [ ] Edit any existing model → checkbox reflects current `is_customer_bookable` value
- [ ] Uncheck the checkbox, save → row updated to `is_customer_bookable=0`
- [ ] Send `ดูทัวร์` again → model no longer in carousel
- [ ] Re-check, save → reappears in carousel

### Regression
- [ ] Save a model without touching the checkbox state → behavior unchanged for the other fields (model_name, type, brand, price, des)
- [ ] Existing models created before #145 (which all have `is_customer_bookable=1` by DEFAULT) still display correctly in both the form and the table

## Out of scope (deferred / optional)

- Visual indicator in the model list table row showing which models are hidden from LINE catalog (eye-with-slash icon, "Hidden" badge). Not blocking; the form already shows the state when admin opens it for edit.
- Bulk-toggle action to flip many models at once.
- Templating the help text via [`LineTemplateRenderer`](app/Services/LineTemplateRenderer.php) so each tenant can customize its label/wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
