### PR TITLE
feat(v6.6): include model.des in tour_bookings.remark for LINE bookings

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -238,12 +238,25 @@ class LineAgentController extends BaseController
             if ($aid) $resolvedAgentId = $aid;
         }
 
-        // Compose remark — captures the tour name + any agent notes +
-        // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id
-        // is deferred to #136 once the bind UI supports agent-tenant users).
+        // Compose remark — captures the tour name + description + any agent
+        // notes + typed agent_code (for audit; auto-resolution to
+        // tour_bookings.agent_id is deferred to #136 once the bind UI
+        // supports agent-tenant users).
+        //
+        // Description is appended after a `|` separator so the operator can
+        // see at a glance which tour was booked without opening the model
+        // record. Stripped of HTML and collapsed whitespace; passed through
+        // verbatim length so long descriptions stay readable in the booking
+        // view (remark column is TEXT — no truncation pressure).
         $remarkParts = [];
         $remarkParts[] = '[from LINE agent text]';
-        $remarkParts[] = 'Tour: ' . ($tour['name'] ?? '');
+        $tourLine = 'Tour: ' . ($tour['name'] ?? '');
+        $modelDes = trim(strip_tags((string)($tour['description'] ?? '')));
+        $modelDes = preg_replace('/\s+/', ' ', $modelDes);
+        if ($modelDes !== '') {
+            $tourLine .= ' | ' . $modelDes;
+        }
+        $remarkParts[] = $tourLine;
         if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code (typed): ' . $fields['agent_code'];
         if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
         $remark = implode("\n", $remarkParts);
@@ -373,7 +386,7 @@ class LineAgentController extends BaseController
         // connection collation (e.g. utf8mb4_bin on staging) differs from the
         // column collation (utf8mb4_unicode_ci).
         $stmt = $db->conn->prepare(
-            "SELECT m.id, m.model_name AS name
+            "SELECT m.id, m.model_name AS name, m.des AS description
              FROM model m
              LEFT JOIN type t ON m.type_id = t.id
              WHERE m.company_id = ?


### PR DESCRIPTION
Operator-requested polish on the LINE-created booking's `remark` field.

## Before

```
[from LINE agent text]
Tour: SM-IT-01-ST
Agent code (typed): TEST001
Notes: smoke test
```

## After

```
[from LINE agent text]
Tour: SM-IT-01-ST | Ang Thong National Marine Park One-Day Trip
Agent code (typed): TEST001
Notes: smoke test
```

## Why

Operators reviewing LINE-created bookings in the iACC admin had to look up the model by code (`SM-IT-01-ST`) to know which tour it actually was. Showing the description inline removes one click per review.

## Change

Single function: `LineAgentController` (covers both bound-agent and customer-direct paths since they share the remark composition block).

| Where | What |
|---|---|
| `matchTour()` SELECT | Add `m.des AS description` alongside the existing `id` + `name`. No new query, no extra DB round-trip. |
| Remark composition | Append `\| <description>` after the tour name when a non-empty description exists. HTML stripped, internal whitespace collapsed. |

Empty descriptions skip the suffix entirely (no trailing `\|`).

No schema changes. No call-site changes outside the controller.

## Files

| File | Δ |
|---|---|
| `app/Controllers/LineAgentController.php` | +18 / −5 |

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` container

## Test plan (staging)

- [ ] Send `จองทัวร์` template → remark on the new `tour_bookings` row reads `Tour: <model_name> | <description>`
- [ ] If you have a tour with no description (`m.des` empty), remark just reads `Tour: <model_name>` (no trailing `\|`)
- [ ] Multi-line / HTML-laden descriptions get collapsed to a single line of plain text in the remark
- [ ] Customer-direct booking path (#134) gets the same enhancement — same code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
