### PR TITLE
fix(v6.6): empty trigger → carousel + parent dropdown shows description

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -137,6 +137,23 @@ class LineAgentController extends BaseController
 
         $lang = $parsed['lang'];
 
+        // v6.6 — when the user sends just the trigger ("จองทัวร์", "book tour")
+        // with no field anchors at all, treat it as "browse intent" and
+        // return the tour carousel instead of an "incomplete booking"
+        // Flex. The carousel guides them to a real tour via the Book
+        // button, which sends back a pre-filled template they can complete.
+        // If the message has at least one anchor, it's an incomplete
+        // booking attempt — fall through to the existing validation Flex.
+        if (!$parsed['ok'] && !\App\Models\AgentBookingParser::hasAnyAnchor($messageText)) {
+            $carousel = \App\Services\LineTourCatalog::buildCarousel($companyId, $lang);
+            return [
+                'handled'        => true,
+                'reason'         => 'browse_intent',
+                'booking_id'     => null,
+                'reply_messages' => [$carousel],
+            ];
+        }
+
         // Validation errors => reply with a missing-fields card
         if (!$parsed['ok']) {
             return [

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -161,10 +161,12 @@ class AgentBookingParser
 
     /**
      * True if the message contains at least one "<field-keyword>:" anchor.
-     * Used to distinguish a structured agent template from a bare legacy
-     * command like "book 2026-04-15 14:00".
+     * Used internally to gate weak triggers, and externally by
+     * LineAgentController to distinguish "browse intent" (`จองทัวร์` alone)
+     * from "incomplete booking attempt" (anchors present but missing
+     * required values).
      */
-    private static function hasAnyAnchor(string $message): bool
+    public static function hasAnyAnchor(string $message): bool
     {
         foreach (self::FIELD_KEYWORDS as $keywords) {
             foreach ($keywords as $kw) {

--- a/app/Models/ProductModel.php
+++ b/app/Models/ProductModel.php
@@ -161,7 +161,10 @@ class ProductModel extends BaseModel
     {
         $companyId = intval($_SESSION['com_id'] ?? 0);
         $excludeId = intval($excludeId);
-        $sql = "SELECT id, model_name FROM model
+        // `des` included so the dropdown can show "SM-IT-01-ST — Ang Thong
+        // Marine Park One-Day Trip" instead of just the code. Helpful for
+        // admins who don't have the model_name → tour mapping memorized.
+        $sql = "SELECT id, model_name, des FROM model
                 WHERE company_id = " . \sql_int($companyId) . "
                   AND deleted_at IS NULL
                   AND parent_model_id IS NULL";

--- a/app/Views/model/list.php
+++ b/app/Views/model/list.php
@@ -210,8 +210,19 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
                 <select class="form-control" name="parent_model_id">
                     <option value="0">— <?= $_isThai ? 'รายการหลัก (ไม่ใช่รายการย่อย)' : 'Top-level (not a sub-item)' ?> —</option>
                     <?php foreach (($parentOptions ?? []) as $p): ?>
+                        <?php
+                            // Show "<model_name> — <description>" so admins recognise
+                            // the tour by name, not just by code.
+                            $_pName = (string)($p['model_name'] ?? '');
+                            $_pDes  = trim(strip_tags((string)($p['des'] ?? '')));
+                            $_pDes  = preg_replace('/\s+/', ' ', $_pDes);
+                            $_pLabel = $_pName;
+                            if ($_pDes !== '') {
+                                $_pLabel .= ' — ' . mb_strimwidth($_pDes, 0, 60, '…');
+                            }
+                        ?>
                         <option value="<?= (int)$p['id'] ?>" <?= $_parentModelId === (int)$p['id'] ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($p['model_name']) ?>
+                            <?= htmlspecialchars($_pLabel) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>


### PR DESCRIPTION
Two small UX polishes from the v6.6 #148 staging test.

## 1. Parent dropdown shows description

**Before:** dropdown rendered just `model_name`:
```
SM-IT-01-ST
SM-PT-11-VIP
SM-SN-02-ST
```
Hard to recognise without memorising codes.

**After:** rendered as `model_name — <description>` (truncated to 60 chars):
```
SM-IT-01-ST — Ang Thong Marine Park One-Day Trip
SM-PT-11-VIP — Full Moon Party Koh Phangan VIP (Fast Boat + Hotel…)
SM-SN-02-ST — Koh Tao & Koh Nang Yuan Snorkeling Tour
```

Strip-tags + whitespace-collapse so HTML or multi-line `m.des` values render cleanly.

## 2. Empty trigger sends the carousel

**Before:** sending `จองทัวร์` (or `book tour`) alone — no field anchors at all — returned the orange "Booking Incomplete" Flex listing all the required fields. Functional but unhelpful when the agent is just starting.

**After:** sending `จองทัวร์` alone returns **the tour carousel** — same one as `ดูทัวร์`. User taps a tour via the Book button → pre-filled template comes back → completes booking.

| What you send | What you get |
|---|---|
| `จองทัวร์` alone | 🎠 Carousel of available tours |
| `จองทัวร์ ทัวร์: SM-IT-01-ST` (any anchor present) | ⚠️ Validation Flex (incomplete booking — same as before) |
| `จองทัวร์ ทัวร์: X วันที่: 2026-06-15 ผู้ใหญ่: 2 ลูกค้า: A มือถือ: 0...` (full template) | ✅ Green Flex with `BK-…` (booking write) |

Discriminator: `AgentBookingParser::hasAnyAnchor` (promoted from private to public). If trigger fired but no field anchors are present → browse intent → carousel. If any anchor is present → incomplete booking attempt → validation Flex (existing behavior).

This is a UX improvement — agents who are unsure of the format see the catalog instead of an error.

## Files

| File | Δ |
|---|---|
| `app/Models/ProductModel.php` | +5 / −1 — getParentOptions returns `des` |
| `app/Models/AgentBookingParser.php` | +5 / −3 — `hasAnyAnchor` promoted to public + docstring updated |
| `app/Views/model/list.php` | +12 / −1 — dropdown renders name + truncated description |
| `app/Controllers/LineAgentController.php` | +17 / 0 — browse-intent branch before validation_failed |

## Verification

- `php -l` clean at PHP 7.4 inside `iacc_php` for all 4 files
- `hasAnyAnchor` smoke-tested across 5 inputs (`จองทัวร์` alone → no anchor; with anchors → has anchor)

## Test plan (staging)

### Parent dropdown polish
- [ ] Open `index.php?page=mo_list&new=1` or edit any model
- [ ] "Sub-item of tour" dropdown now shows `SM-IT-01-ST — Ang Thong …` etc instead of bare codes

### Empty trigger → carousel
- [ ] Send `จองทัวร์` alone via LINE → carousel of tours appears (same as `ดูทัวร์`)
- [ ] Send `book tour` alone → English carousel appears
- [ ] Send `จองทัวร์ ทัวร์: WRONG_NAME` → orange "Booking Incomplete" or "Tour not found" Flex (existing behavior — has anchor)
- [ ] Send the full structured template → ✅ green booking Flex (existing behavior unchanged)
- [ ] Send `book 2026-06-15 14:00` (legacy bare command) → legacy redirect message (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
