### PR TITLE
fix(v6.6): carry carousel language through postback to prefill reply

### DIFF
--- a/app/Services/LineTourCatalog.php
+++ b/app/Services/LineTourCatalog.php
@@ -81,7 +81,7 @@ class LineTourCatalog
 
         $bubbles = [];
         foreach ($tours as $t) {
-            $bubbles[] = self::buildBubble($t, $isThai);
+            $bubbles[] = self::buildBubble($t, $isThai, $lang);
         }
 
         return [
@@ -225,7 +225,7 @@ class LineTourCatalog
      *   - Body: model_name (bold, larger), description preview, price line
      *   - Footer: "Book this" postback button
      */
-    private static function buildBubble(array $tour, bool $isThai): array
+    private static function buildBubble(array $tour, bool $isThai, string $lang = 'en'): array
     {
         $title       = (string)($tour['model_name'] ?? '');
         $category    = (string)($tour['type_name']  ?? '');
@@ -273,7 +273,12 @@ class LineTourCatalog
                             // displayText shows in the chat as if the user typed
                             // it — gives them a record of which tour they picked.
                             'displayText' => ($isThai ? 'จองทัวร์: ' : 'Book: ') . $title,
-                            'data'  => 'action=prefill_booking&tour_id=' . intval($tour['id']),
+                            // Carry the carousel's language back through
+                            // the postback so the prefill reply matches —
+                            // detecting from display_name is unreliable
+                            // (Thai users with English-spelled names
+                            // would land on the wrong template).
+                            'data'  => 'action=prefill_booking&tour_id=' . intval($tour['id']) . '&lang=' . ($lang === 'th' ? 'th' : 'en'),
                         ],
                     ],
                 ],

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -293,11 +293,19 @@ function handlePostback(array $event, int $companyId, int $dbUserId, \App\Models
             // template scoped to the tenant; defensive against postback
             // tampering via the tenancy filter in fetchTour().
             $tourId = intval($params['tour_id'] ?? 0);
-            // Use the LINE user's last inbound message language as a hint
-            // for the reply language; default EN for postbacks (button
-            // taps don't carry text).
-            $lineUser = $model->getLineUserById($dbUserId);
-            $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+            // Language is carried in the postback data (set by the
+            // carousel that produced the button), so the prefill reply
+            // matches the user's original message language. Falls back
+            // to the LINE display_name regex only when lang is missing —
+            // unreliable for Thai users with English-spelled names but
+            // a reasonable last resort for legacy carousels.
+            $postbackLang = (string)($params['lang'] ?? '');
+            if ($postbackLang === 'th' || $postbackLang === 'en') {
+                $lang = $postbackLang;
+            } else {
+                $lineUser = $model->getLineUserById($dbUserId);
+                $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+            }
             $reply = \App\Services\LineTourCatalog::buildPrefillReply($companyId, $tourId, $lang);
             if ($reply) {
                 $service->replyMessage($replyToken, [$reply]);


### PR DESCRIPTION
Operator caught: tapping 'Book this' on a Thai carousel returned the English prefill template for users like 'Sinthorn' (Thai person, English-spelled display name). The handler was guessing language from `display_name` — wrong for Thai-with-English-name customers.

## Fix

Encode the carousel's language into the postback data:

```
action=prefill_booking&tour_id=418&lang=th
```

When the user taps Book, the handler reads `lang` from the postback (matches the original message language) instead of guessing from `display_name`.

## Files

- `app/Services/LineTourCatalog.php` — `buildBubble` accepts lang + appends to postback data
- `line-webhook.php` — `handlePostback` reads `$params['lang']` first, falls back to display_name regex only when missing (legacy carousels from before this PR)

## Verification

```
TH carousel button data: action=prefill_booking&tour_id=418&lang=th  ✅
TH carousel book label : 📝 จองทัวร์นี้                              ✅
EN carousel button data: action=prefill_booking&tour_id=418&lang=en  ✅
EN carousel book label : 📝 Book this                                ✅
```

## Test plan (staging)

- [ ] Send `จองทัวร์` (Thai) → carousel appears with Thai "📝 จองทัวร์นี้" buttons
- [ ] Tap Book on any tour → pre-filled template comes back **in Thai** ("จองทัวร์\nทัวร์: ...\nวันที่: ...")
- [ ] Send `book tour` (English) → carousel with "📝 Book this" buttons
- [ ] Tap Book → pre-filled template **in English**

🤖 Generated with [Claude Code](https://claude.com/claude-code)