### PR TITLE
fix(v6.6): postback prefill — use recent message language as fallback

### DIFF
--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -148,6 +148,39 @@ class LineOA extends BaseModel
         return $result;
     }
 
+    /**
+     * v6.6 — Detect language preference for a LINE user from their most
+     * recent inbound text message. Returns 'th' if Thai script appears,
+     * 'en' if a non-Thai text message exists, or null when the user has
+     * no text history.
+     *
+     * Used by postback handlers (e.g. carousel "Book this") to figure
+     * out which language the user is currently using when the postback
+     * data itself doesn't carry it (legacy carousels rendered before
+     * v6.6 #150). Far more reliable than guessing from display_name,
+     * which fails for Thai users with English-spelled names.
+     */
+    public function getRecentLanguage(int $companyId, int $lineUserDbId): ?string
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT content FROM line_messages
+             WHERE company_id = ?
+               AND line_user_id = ?
+               AND direction = 'inbound'
+               AND message_type = 'text'
+             ORDER BY id DESC
+             LIMIT 1"
+        );
+        $stmt->bind_param('ii', $companyId, $lineUserDbId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$row) return null;
+        $content = (string)($row['content'] ?? '');
+        if ($content === '') return null;
+        return preg_match('/[\x{0E00}-\x{0E7F}]/u', $content) ? 'th' : 'en';
+    }
+
     public function getLineUserById(int $id): ?array
     {
         $stmt = $this->conn->prepare("SELECT * FROM line_users WHERE id = ?");

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -293,18 +293,25 @@ function handlePostback(array $event, int $companyId, int $dbUserId, \App\Models
             // template scoped to the tenant; defensive against postback
             // tampering via the tenancy filter in fetchTour().
             $tourId = intval($params['tour_id'] ?? 0);
-            // Language is carried in the postback data (set by the
-            // carousel that produced the button), so the prefill reply
-            // matches the user's original message language. Falls back
-            // to the LINE display_name regex only when lang is missing —
-            // unreliable for Thai users with English-spelled names but
-            // a reasonable last resort for legacy carousels.
+            // Language resolution priority:
+            //   1. $params['lang'] from the postback data (set by the
+            //      carousel in v6.6 #150) — authoritative if present.
+            //   2. The user's most recent inbound text message — reliable
+            //      since the carousel-trigger message is always more
+            //      recent than the bubble being tapped. Catches legacy
+            //      carousels rendered before #150.
+            //   3. display_name regex — last resort. Unreliable for Thai
+            //      users with English-spelled names ("Sinthorn") but
+            //      better than nothing for users with no text history.
             $postbackLang = (string)($params['lang'] ?? '');
             if ($postbackLang === 'th' || $postbackLang === 'en') {
                 $lang = $postbackLang;
             } else {
-                $lineUser = $model->getLineUserById($dbUserId);
-                $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+                $lang = $model->getRecentLanguage($companyId, $dbUserId);
+                if ($lang === null) {
+                    $lineUser = $model->getLineUserById($dbUserId);
+                    $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+                }
             }
             $reply = \App\Services\LineTourCatalog::buildPrefillReply($companyId, $tourId, $lang);
             if ($reply) {


### PR DESCRIPTION
Stacks on top of #150. Catches the legacy-carousel case where the postback data doesn't carry `lang`.

## Why

PR #150 added `&lang=th|en` to carousel button postbacks so the prefill template language matches what the user typed. Worked perfectly for **new** carousels.

But carousels rendered **before #150 deployed** don't have `lang` in their postback data. When a user taps Book on one of those legacy buttons, the handler falls back to the display_name regex — wrong for the very common Thai-with-English-name case ("Sinthorn").

## Fix

Better fallback: detect language from the user's **most recent inbound text message**. The carousel-trigger message (`จองทัวร์` / `ดูทัวร์`) is always more recent than the bubble being tapped, so this catches every case where the user just used Thai to ask for the catalog.

## Resolution chain in `handlePostback prefill_booking`

1. `$params['lang']` — set by carousels rendered after #150
2. **NEW: `LineOA::getRecentLanguage`** — detects from latest inbound text message
3. `display_name` regex — last resort, covers users with no message history yet

## Files

| File | Δ |
|---|---|
| `app/Models/LineOA.php` | +33 — new `getRecentLanguage($companyId, $dbUserId)` method |
| `line-webhook.php` | +15 / -8 — postback handler uses the new fallback chain |

## Test plan (staging)

- [ ] **Legacy carousel test:** an OLD carousel from before #150 deployed. Tap Book on a tour. Expect: pre-filled template now comes back **in Thai** (was English before this PR), because your last `ดูทัวร์` / `จองทัวร์` message was Thai.
- [ ] **New carousel test:** send `จองทัวร์` to get a fresh carousel (post-#150). Tap Book. Same result — Thai template — but this time via path 1 (`$params['lang']`).
- [ ] **Edge case:** brand-new LINE user who's never sent a text message taps a postback (rare). Falls back to display_name regex — same behavior as before this PR for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)