### PR TITLE
release(v6.6): Customer-Direct LINE Booking + Auto-Seed + Sub-Models

### DIFF
--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -238,12 +238,53 @@ class LineAgentController extends BaseController
             if ($aid) $resolvedAgentId = $aid;
         }
 
-        // Compose remark — captures the tour name + any agent notes +
-        // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id
-        // is deferred to #136 once the bind UI supports agent-tenant users).
+        // v6.6 — resolve customer nationality. Priority chain:
+        //   1. Explicit สัญชาติ: / nationality: field (raw value preserved
+        //      for marketing — "USA", "CHN", "Thai" etc.)
+        //   2. Heuristic: Thai script in customer name → "Thai"
+        //   3. Otherwise blank, charged as Foreigner
+        //
+        // The raw value goes to tour_booking_contacts.nationality so
+        // marketing reports can group by country. Pricing decision is
+        // binary (Thai vs Foreigner) — drives qty_thai/qty_foreigner.
+        $nationalityRaw = trim($fields['nationality'] ?? '');
+        $natAutoDetected = false;
+        if ($nationalityRaw === '') {
+            $natAutoDetected = true;
+            if (preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($fields['customer_name'] ?? ''))) {
+                $nationalityRaw = 'Thai';
+            }
+            // else: leave blank — pricing falls to Foreigner; admin can
+            // fill in actual country later via the booking detail page.
+        }
+        $isThaiPricing = $nationalityRaw !== '' && in_array(
+            mb_strtolower($nationalityRaw),
+            ['thai', 'th', 'ไทย'],
+            true
+        );
+
+        // Compose remark — captures the tour name + description, resolved
+        // nationality + auto-detect flag, any agent notes + typed
+        // agent_code (audit). Description added in v6.6 (folded #147 in)
+        // so admin can ID the tour without opening the model record.
         $remarkParts = [];
         $remarkParts[] = '[from LINE agent text]';
-        $remarkParts[] = 'Tour: ' . ($tour['name'] ?? '');
+        $tourLine = 'Tour: ' . ($tour['name'] ?? '');
+        $modelDes = trim(strip_tags((string)($tour['description'] ?? '')));
+        $modelDes = preg_replace('/\s+/', ' ', $modelDes);
+        if ($modelDes !== '') $tourLine .= ' | ' . $modelDes;
+        $remarkParts[] = $tourLine;
+        // Nationality marker — explicit visibility for the admin who
+        // reviews the booking and may need to correct an auto-detection.
+        $natLine = 'Nationality: ';
+        if ($nationalityRaw === '') {
+            $natLine .= '(not detected — billed as Foreigner; please verify before invoicing)';
+        } elseif ($natAutoDetected) {
+            $natLine .= $nationalityRaw . ' (auto-detected from name script — please verify)';
+        } else {
+            $natLine .= $nationalityRaw . ' (specified by sender)';
+        }
+        $remarkParts[] = $natLine;
         if (!empty($fields['agent_code'])) $remarkParts[] = 'Agent code (typed): ' . $fields['agent_code'];
         if (!empty($fields['notes']))      $remarkParts[] = 'Notes: ' . $fields['notes'];
         $remark = implode("\n", $remarkParts);
@@ -290,15 +331,33 @@ class LineAgentController extends BaseController
             $bookingId = $tourBookingModel->createBooking($bookingData);
 
             // Per-booking customer contact row (proper home for name +
-            // mobile + email + messenger, replacing the "stuff into booking_by"
-            // placeholder from the original #120 PR).
+            // mobile + email + messenger + nationality, replacing the
+            // "stuff into booking_by" placeholder from the original #120 PR).
             if ($bookingId > 0) {
                 $tourBookingModel->saveBookingContact($bookingId, [
                     'contact_name'       => $fields['customer_name']  ?? '',
                     'mobile'             => $fields['customer_mobile'] ?? '',
-                    'email'              => $fields['email']          ?? '',
+                    'email'               => $fields['email']         ?? '',
                     'contact_messengers' => $fields['messenger']      ?? '',
+                    // Raw value preserved for marketing (USA / CHN / Thai
+                    // / etc.). Empty string when heuristic couldn't infer
+                    // — admin fills in later from the customer details.
+                    'nationality'        => $nationalityRaw,
                 ]);
+
+                // v6.6 — auto-seed line items: parent tour + any sub-models
+                // (entrance fees / extras tagged via parent_model_id). qty
+                // and price are split by Thai/Foreigner per the resolved
+                // nationality. Admin can edit prices / split nationalities
+                // / add more items via the existing booking detail UI.
+                self::autoSeedItems(
+                    $tourBookingModel,
+                    $bookingId,
+                    $companyId,
+                    $tour,
+                    $totalPax,
+                    $isThaiPricing
+                );
 
                 // Visibility: log a webhook event when status fell to draft
                 // due to allotment so the operator can act on it.
@@ -357,6 +416,103 @@ class LineAgentController extends BaseController
     // ====================================================================
 
     /**
+     * v6.6 — auto-seed `tour_booking_items` rows from the matched parent
+     * tour and any active sub-models (entrance fees / extras). Updates
+     * the booking's subtotal / total_amount / amount_due to match the
+     * sum so the booking detail page shows the right grand total.
+     *
+     * Pricing strategy:
+     *   - Both `price_thai` and `price_foreigner` default to the model's
+     *     `price`. When admin runs different rates for nationality, they
+     *     edit the relevant column on the booking detail items grid.
+     *   - `qty_thai` / `qty_foreigner` is the full booking pax routed by
+     *     the resolved nationality (binary). Mixed groups handled in the
+     *     web booking form.
+     */
+    private static function autoSeedItems(
+        \App\Models\TourBooking $tbm,
+        int $bookingId,
+        int $companyId,
+        array $tour,
+        int $totalPax,
+        bool $isThaiPricing
+    ): void {
+        if ($totalPax <= 0 || $bookingId <= 0) return;
+
+        $items = [];
+        $items[] = self::buildItemRow($tour, $totalPax, $isThaiPricing, 'tour');
+
+        // Sub-models: entrance fees / extras tagged via parent_model_id.
+        $productModel = new \App\Models\ProductModel();
+        $children = $productModel->getChildModels((int)($tour['id'] ?? 0), $companyId);
+        foreach ($children as $child) {
+            $items[] = self::buildItemRow($child, $totalPax, $isThaiPricing, 'entrance');
+        }
+
+        $tbm->saveBookingItems($bookingId, $items);
+
+        // Recompute booking totals from the items just inserted. The
+        // saveBookingItems helper doesn't touch tour_bookings, so the
+        // grand total stays at 0 unless we update it explicitly.
+        $subtotal = 0.0;
+        foreach ($items as $item) {
+            $subtotal += ($item['qty_thai']      ?? 0) * ($item['price_thai']      ?? 0);
+            $subtotal += ($item['qty_foreigner'] ?? 0) * ($item['price_foreigner'] ?? 0);
+        }
+        self::updateBookingTotals($companyId, $bookingId, $subtotal);
+    }
+
+    /**
+     * v6.6 — Compose one `tour_booking_items` row from a model record.
+     * Accepts both shapes: matchTour result (id/name/description) and
+     * ProductModel::getChildModels result (id/model_name/des).
+     */
+    private static function buildItemRow(array $model, int $qty, bool $isThai, string $itemType): array
+    {
+        $name = (string)($model['name']        ?? $model['model_name'] ?? '');
+        $des  = (string)($model['description'] ?? $model['des']        ?? '');
+        $des  = trim(strip_tags($des));
+        $des  = preg_replace('/\s+/', ' ', $des);
+
+        $description = $name;
+        if ($des !== '') $description .= ' | ' . $des;
+        if (mb_strlen($description) > 400) {
+            $description = mb_substr($description, 0, 397) . '…';
+        }
+
+        $price = floatval($model['price'] ?? 0);
+
+        return [
+            'item_type'       => $itemType,
+            'description'     => $description,
+            'qty_thai'        => $isThai ? $qty : 0,
+            'qty_foreigner'   => $isThai ? 0   : $qty,
+            'price_thai'      => $price,
+            'price_foreigner' => $price,
+            'product_type_id' => intval($model['type_id'] ?? 0),
+            'model_id'        => intval($model['id']      ?? 0),
+            'pax_lines_json'  => '[]',
+        ];
+    }
+
+    /**
+     * v6.6 — Push the auto-seeded subtotal back to the booking row so
+     * the booking detail page shows correct numbers. Tenancy-scoped.
+     */
+    private static function updateBookingTotals(int $companyId, int $bookingId, float $subtotal): void
+    {
+        global $db;
+        $stmt = $db->conn->prepare(
+            "UPDATE tour_bookings
+             SET subtotal = ?, total_amount = ?, amount_due = ?
+             WHERE id = ? AND company_id = ?"
+        );
+        $stmt->bind_param('dddii', $subtotal, $subtotal, $subtotal, $bookingId, $companyId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /**
      * Fuzzy match a tour name against the company's `model` table
      * (joined with `type` so agents can match by category name too).
      * Returns ['status' => 'none'|'one'|'multiple', 'tour' => array|null, 'candidates' => array]
@@ -372,13 +528,19 @@ class LineAgentController extends BaseController
         // Without this, MySQL throws "Illegal mix of collations" when the
         // connection collation (e.g. utf8mb4_bin on staging) differs from the
         // column collation (utf8mb4_unicode_ci).
+        // v6.6 — also pull description, price, type_id so auto-seed has
+        // everything it needs without a second round-trip. The carousel
+        // and parent-only filter ensure agents/customers can only book
+        // top-level models (parent_model_id IS NULL).
         $stmt = $db->conn->prepare(
-            "SELECT m.id, m.model_name AS name
+            "SELECT m.id, m.model_name AS name, m.des AS description,
+                    m.price, m.type_id
              FROM model m
              LEFT JOIN type t ON m.type_id = t.id
              WHERE m.company_id = ?
                AND m.deleted_at IS NULL
                AND m.is_active = 1
+               AND m.parent_model_id IS NULL
                AND (m.model_name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%')
                     OR CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', m.model_name, '%')
                     OR t.name LIKE CONCAT('%', CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci, '%'))
@@ -396,12 +558,11 @@ class LineAgentController extends BaseController
     }
 
     // ----- Flex / text reply builders -----
-
-    private static function buildPlainText(string $template, array $vars = []): array
-    {
-        $text = $vars ? vsprintf($template, $vars) : $template;
-        return ['type' => 'text', 'text' => $text];
-    }
+    //
+    // Plain-text replies (tour_not_found, tour_ambiguous, write_failed)
+    // are rendered through LineTemplateRenderer (#133) — no local helper
+    // needed here. Flex builders are kept locally because conditional row
+    // rendering doesn't fit the current renderer (Phase 2 will tackle it).
 
     private static function buildSuccessFlex(string $bookingNumber, array $tour, array $fields, string $lang, bool $pastDateWarn, array $statusInfo = ['status' => 'confirmed', 'reason' => 'available']): array
     {

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -38,10 +38,17 @@ class LineAgentController extends BaseController
         }
         $companyId = (int)$this->user['com_id'];
         $bindings  = $this->lineModel->getAgentBindings($companyId);
-        $iaccUsers = $this->lineModel->getEligibleIaccUsers($companyId);
+        // #136: two scopes — operator's own team vs registered agent partners.
+        // The view renders both as tabs so admins can pick the right pool of
+        // iACC users when binding a LINE account.
+        $iaccUsers         = $this->lineModel->getEligibleIaccUsers($companyId);
+        $agentTenantUsers  = $this->lineModel->getEligibleAgentTenantUsers($companyId);
+        $scope             = ($_GET['scope'] ?? 'team') === 'partners' ? 'partners' : 'team';
         $this->render('line-oa/agent-bindings', [
-            'bindings'  => $bindings,
-            'iaccUsers' => $iaccUsers,
+            'bindings'         => $bindings,
+            'iaccUsers'        => $iaccUsers,
+            'agentTenantUsers' => $agentTenantUsers,
+            'scope'            => $scope,
         ]);
     }
 
@@ -209,6 +216,17 @@ class LineAgentController extends BaseController
             $bookingByName = 'User #' . $iaccUserId;
         }
 
+        // #136: auto-resolve agent_id from the bound user. If the bound user
+        // belongs to an agent-partner tenant, this returns the matching
+        // tour_agent_profiles.id and the booking is attributed to that
+        // partner for commission tracking. Operator's own employees return
+        // null (agent_id stays 0 — they're sales reps, not partner agents).
+        $resolvedAgentId = 0;
+        if ($boundUser && !empty($boundUser['user_com_id'])) {
+            $aid = $line->resolveAgentIdFromBoundUser($companyId, (int)$boundUser['user_com_id']);
+            if ($aid) $resolvedAgentId = $aid;
+        }
+
         // Compose remark — captures the tour name + any agent notes +
         // typed agent_code (for audit; auto-resolution to tour_bookings.agent_id
         // is deferred to #136 once the bind UI supports agent-tenant users).
@@ -235,7 +253,7 @@ class LineAgentController extends BaseController
                 'booking_number' => $bookingNumber,
                 'booking_date'   => date('Y-m-d'),
                 'travel_date'    => $fields['date'],
-                'agent_id'       => 0, // deferred to #136
+                'agent_id'       => $resolvedAgentId, // #136: auto from binding when partner-tenant
                 'sales_rep_id'   => 0,
                 'customer_id'    => 0,
                 'booking_by'     => $bookingByName,

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -156,17 +156,22 @@ class LineAgentController extends BaseController
         $iaccUserId   = $line->getBoundIaccUserId($companyId, $lineUserIdStr);
         $isBoundAgent = !empty($iaccUserId);
 
-        // Match the tour name within the tenant's tours
+        // Match the tour name within the tenant's tours.
+        // The "not found" / "ambiguous" replies go through LineTemplateRenderer
+        // (#133 Phase 1) so admins can customize the wording per tenant via
+        // the existing template-edit.php page. Hardcoded defaults stay as
+        // the fallback when no per-tenant override exists.
         $tourMatch = self::matchTour($companyId, $fields['tour_name']);
         if ($tourMatch['status'] === 'none') {
+            $msg = \App\Services\LineTemplateRenderer::renderText(
+                $companyId, 'agent.tour_not_found', $lang,
+                ['tour_name' => $fields['tour_name']]
+            );
             return [
                 'handled'        => true,
                 'reason'         => 'tour_not_found',
                 'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText(($lang === 'th'
-                    ? 'ไม่พบทัวร์ที่ตรงกับ "%s" ในระบบ'
-                    : 'No tour matching "%s" found in your system.'),
-                    [$fields['tour_name']])],
+                'reply_messages' => [['type' => 'text', 'text' => $msg]],
             ];
         }
         if ($tourMatch['status'] === 'multiple') {
@@ -174,14 +179,15 @@ class LineAgentController extends BaseController
             foreach ($tourMatch['candidates'] as $i => $c) {
                 $list .= ($i + 1) . ') ' . $c['name'] . "\n";
             }
+            $msg = \App\Services\LineTemplateRenderer::renderText(
+                $companyId, 'agent.tour_ambiguous', $lang,
+                ['candidates' => $list]
+            );
             return [
                 'handled'        => true,
                 'reason'         => 'tour_ambiguous',
                 'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText(($lang === 'th'
-                    ? "พบทัวร์หลายรายการที่ตรงกัน:\n%sกรุณาส่งใหม่พร้อมระบุชื่อให้ชัดเจนยิ่งขึ้น"
-                    : "Multiple tours matched:\n%sPlease re-send with a more specific name."),
-                    [$list])],
+                'reply_messages' => [['type' => 'text', 'text' => $msg]],
             ];
         }
 
@@ -327,13 +333,14 @@ class LineAgentController extends BaseController
         }
 
         if ($bookingId <= 0) {
+            $msg = \App\Services\LineTemplateRenderer::renderText(
+                $companyId, 'agent.write_failed', $lang
+            );
             return [
                 'handled'        => true,
                 'reason'         => 'write_failed',
                 'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText($lang === 'th'
-                    ? 'เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ'
-                    : 'Could not save the booking. Please contact your admin.')],
+                'reply_messages' => [['type' => 'text', 'text' => $msg]],
             ];
         }
 

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -137,6 +137,23 @@ class LineAgentController extends BaseController
 
         $lang = $parsed['lang'];
 
+        // v6.6 — when the user sends just the trigger ("จองทัวร์", "book tour")
+        // with no field anchors at all, treat it as "browse intent" and
+        // return the tour carousel instead of an "incomplete booking"
+        // Flex. The carousel guides them to a real tour via the Book
+        // button, which sends back a pre-filled template they can complete.
+        // If the message has at least one anchor, it's an incomplete
+        // booking attempt — fall through to the existing validation Flex.
+        if (!$parsed['ok'] && !\App\Models\AgentBookingParser::hasAnyAnchor($messageText)) {
+            $carousel = \App\Services\LineTourCatalog::buildCarousel($companyId, $lang);
+            return [
+                'handled'        => true,
+                'reason'         => 'browse_intent',
+                'booking_id'     => null,
+                'reply_messages' => [$carousel],
+            ];
+        }
+
         // Validation errors => reply with a missing-fields card
         if (!$parsed['ok']) {
             return [

--- a/app/Controllers/LineAgentController.php
+++ b/app/Controllers/LineAgentController.php
@@ -149,19 +149,12 @@ class LineAgentController extends BaseController
 
         $fields = $parsed['fields'];
 
-        // Resolve the bound iACC user
+        // Resolve the bound iACC user (may be null in v6.6 #134 — customers
+        // sending the structured template directly aren't required to be
+        // bound as agents; we just attribute the booking differently below).
         $line = new \App\Models\LineOA();
-        $iaccUserId = $line->getBoundIaccUserId($companyId, $lineUserIdStr);
-        if (!$iaccUserId) {
-            return [
-                'handled'        => true,
-                'reason'         => 'not_bound',
-                'booking_id'     => null,
-                'reply_messages' => [self::buildPlainText($lang === 'th'
-                    ? 'คุณยังไม่ได้รับการผูกบัญชีเป็นตัวแทน กรุณาติดต่อผู้ดูแลระบบ'
-                    : 'Your LINE account is not bound as an agent. Please contact your admin.')],
-            ];
-        }
+        $iaccUserId   = $line->getBoundIaccUserId($companyId, $lineUserIdStr);
+        $isBoundAgent = !empty($iaccUserId);
 
         // Match the tour name within the tenant's tours
         $tourMatch = self::matchTour($companyId, $fields['tour_name']);
@@ -198,14 +191,20 @@ class LineAgentController extends BaseController
         // Past-date warning prefix for the reply (still write the booking)
         $pastDateWarn = $parser::isDatePast($fields['date']);
 
-        // Resolve the bound user's display name for booking_by (was the
-        // customer name+phone before #132 — semantically wrong).
-        // Priority: name → email → bare "User #ID" sentinel. Empty strings
-        // (not just nulls) also fall through, since some authorize rows have
-        // name='' rather than NULL.
-        $boundUser = $line->getBoundUserDetails($companyId, $lineUserIdStr);
+        // Compose booking_by — the human-readable identity of who entered
+        // the booking. Two paths:
+        //
+        //   Bound agent (#132): name → email → "User #ID" sentinel from the
+        //     bound authorize row. Empty strings fall through too.
+        //
+        //   Direct customer (#134): the LINE user's display_name from
+        //     line_users, suffixed with " [LINE customer]" so the operator
+        //     can tell at a glance this booking came in via LINE without an
+        //     agent attribution. Falls back to a bare sentinel if display
+        //     name is missing.
+        $boundUser     = $isBoundAgent ? $line->getBoundUserDetails($companyId, $lineUserIdStr) : null;
         $bookingByName = '';
-        if ($boundUser) {
+        if ($isBoundAgent && $boundUser) {
             if (!empty($boundUser['authorize_name'])) {
                 $bookingByName = $boundUser['authorize_name'];
             } elseif (!empty($boundUser['email'])) {
@@ -213,16 +212,22 @@ class LineAgentController extends BaseController
             }
         }
         if ($bookingByName === '') {
-            $bookingByName = 'User #' . $iaccUserId;
+            if ($isBoundAgent) {
+                $bookingByName = 'User #' . $iaccUserId;
+            } else {
+                $lineUserRow  = $line->getLineUserByLineId($companyId, $lineUserIdStr);
+                $displayName  = trim($lineUserRow['display_name'] ?? '');
+                $bookingByName = $displayName !== ''
+                    ? ($displayName . ' [LINE customer]')
+                    : '[LINE customer]';
+            }
         }
 
-        // #136: auto-resolve agent_id from the bound user. If the bound user
-        // belongs to an agent-partner tenant, this returns the matching
-        // tour_agent_profiles.id and the booking is attributed to that
-        // partner for commission tracking. Operator's own employees return
-        // null (agent_id stays 0 — they're sales reps, not partner agents).
+        // #136: auto-resolve agent_id from the bound user. Only fires when
+        // the user is bound AND lives in an agent-partner tenant — direct
+        // customers never have an agent attribution.
         $resolvedAgentId = 0;
-        if ($boundUser && !empty($boundUser['user_com_id'])) {
+        if ($isBoundAgent && $boundUser && !empty($boundUser['user_com_id'])) {
             $aid = $line->resolveAgentIdFromBoundUser($companyId, (int)$boundUser['user_com_id']);
             if ($aid) $resolvedAgentId = $aid;
         }
@@ -264,8 +269,16 @@ class LineAgentController extends BaseController
                 'pickup_room'    => $fields['room'] ?? '',
                 'status'         => $statusInfo['status'],
                 'remark'         => $remark,
-                'created_by'     => $boundUser['authorize_id'] ?? $iaccUserId,
-                'created_via'    => 'line_oa_agent_text',
+                // Bound agent: attribute to their authorize.id.
+                // Direct customer: created_by stays NULL (no iACC user).
+                'created_by'     => $isBoundAgent
+                    ? ($boundUser['authorize_id'] ?? $iaccUserId)
+                    : null,
+                // Distinguish the two source channels for reporting and
+                // future per-channel automation.
+                'created_via'    => $isBoundAgent
+                    ? 'line_oa_agent_text'
+                    : 'line_oa_customer_text',
             ];
 
             $bookingId = $tourBookingModel->createBooking($bookingData);

--- a/app/Controllers/ModelController.php
+++ b/app/Controllers/ModelController.php
@@ -47,22 +47,27 @@ class ModelController extends BaseController
         // Dropdown data
         $types  = $this->model->getTypes();
         $brands = $this->model->getBrands();
+        // v6.6 — parent-model options for the sub-model dropdown.
+        // Excludes the current row when editing so a model can't pick
+        // itself as a parent.
+        $parentOptions = $this->model->getParentOptions($editId);
 
         $this->render('model/list', [
-            'items'        => $result['items'],
-            'total_items'  => $result['total'],
-            'item_count'   => $result['count'],
-            'pagination'   => $result['pagination'],
-            'stats'        => $this->model->getStats(),
-            'search'       => $search,
-            'status'       => $status,
-            'type_id'      => $typeId,
-            'brand_id'     => $brandId,
-            'edit_data'    => $editData,
-            'show_form'    => $showForm,
-            'types'        => $types,
-            'brands'       => $brands,
-            'query_params' => $_GET,
+            'items'         => $result['items'],
+            'total_items'   => $result['total'],
+            'item_count'    => $result['count'],
+            'pagination'    => $result['pagination'],
+            'stats'         => $this->model->getStats(),
+            'search'        => $search,
+            'status'        => $status,
+            'type_id'       => $typeId,
+            'brand_id'      => $brandId,
+            'edit_data'     => $editData,
+            'show_form'     => $showForm,
+            'types'         => $types,
+            'brands'        => $brands,
+            'parentOptions' => $parentOptions,
+            'query_params'  => $_GET,
         ]);
     }
 
@@ -86,6 +91,13 @@ class ModelController extends BaseController
         // unchecked checkboxes don't submit, so absence means "uncheck"
         // (i.e. hide from carousel). New rows default to visible.
         $isCustomerBookable = isset($_POST['is_customer_bookable']) ? 1 : 0;
+        // v6.6 — parent_model_id for sub-model relationships. 0 / empty in
+        // the form means "top-level" → store NULL. Self-reference guarded
+        // at the form level (current row is excluded from the dropdown
+        // options) but we also enforce no self-parent on the server side.
+        $parentModelId = intval($_POST['parent_model_id'] ?? 0);
+        if ($parentModelId === $id) $parentModelId = 0;
+        $parentValue   = $parentModelId > 0 ? $parentModelId : null;
 
         switch ($method) {
             case 'A': // Add
@@ -97,6 +109,7 @@ class ModelController extends BaseController
                     'des'                  => $des,
                     'price'                => $price,
                     'is_customer_bookable' => $isCustomerBookable,
+                    'parent_model_id'      => $parentValue,
                 ]);
                 break;
 
@@ -107,6 +120,7 @@ class ModelController extends BaseController
                         'des'                  => $des,
                         'price'                => $price,
                         'is_customer_bookable' => $isCustomerBookable,
+                        'parent_model_id'      => $parentValue,
                     ];
                     if ($typeId > 0)  $data['type_id']  = $typeId;
                     if ($brandId > 0) $data['brand_id'] = $brandId;

--- a/app/Controllers/ModelController.php
+++ b/app/Controllers/ModelController.php
@@ -82,25 +82,31 @@ class ModelController extends BaseController
         $price     = floatval($_REQUEST['price'] ?? 0);
         $des       = $this->inputStr('des', '');
         $companyId = $this->getCompanyId();
+        // v6.6 #135 follow-up — LINE catalog visibility toggle. HTML
+        // unchecked checkboxes don't submit, so absence means "uncheck"
+        // (i.e. hide from carousel). New rows default to visible.
+        $isCustomerBookable = isset($_POST['is_customer_bookable']) ? 1 : 0;
 
         switch ($method) {
             case 'A': // Add
                 $this->model->create([
-                    'company_id' => $companyId,
-                    'type_id'    => $typeId,
-                    'brand_id'   => $brandId,
-                    'model_name' => $modelName,
-                    'des'        => $des,
-                    'price'      => $price,
+                    'company_id'           => $companyId,
+                    'type_id'              => $typeId,
+                    'brand_id'             => $brandId,
+                    'model_name'           => $modelName,
+                    'des'                  => $des,
+                    'price'                => $price,
+                    'is_customer_bookable' => $isCustomerBookable,
                 ]);
                 break;
 
             case 'E': // Edit
                 if ($id > 0) {
                     $data = [
-                        'model_name' => $modelName,
-                        'des'        => $des,
-                        'price'      => $price,
+                        'model_name'           => $modelName,
+                        'des'                  => $des,
+                        'price'                => $price,
+                        'is_customer_bookable' => $isCustomerBookable,
                     ];
                     if ($typeId > 0)  $data['type_id']  = $typeId;
                     if ($brandId > 0) $data['brand_id'] = $brandId;

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -161,10 +161,12 @@ class AgentBookingParser
 
     /**
      * True if the message contains at least one "<field-keyword>:" anchor.
-     * Used to distinguish a structured agent template from a bare legacy
-     * command like "book 2026-04-15 14:00".
+     * Used internally to gate weak triggers, and externally by
+     * LineAgentController to distinguish "browse intent" (`จองทัวร์` alone)
+     * from "incomplete booking attempt" (anchors present but missing
+     * required values).
      */
-    private static function hasAnyAnchor(string $message): bool
+    public static function hasAnyAnchor(string $message): bool
     {
         foreach (self::FIELD_KEYWORDS as $keywords) {
             foreach ($keywords as $kw) {

--- a/app/Models/AgentBookingParser.php
+++ b/app/Models/AgentBookingParser.php
@@ -76,6 +76,7 @@ class AgentBookingParser
         'email'          => ['อีเมล', 'email'],
         'messenger'      => ['เมสเซนเจอร์', 'messenger'],
         'agent_code'     => ['ตัวแทน', 'agent'],
+        'nationality'    => ['สัญชาติ', 'nationality'],
         'accommodation'  => ['ที่พัก', 'accommodation'],
         'room'           => ['หมายเลขห้อง', 'room'],
         'notes'          => ['หมายเหตุ', 'notes'],

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -148,6 +148,39 @@ class LineOA extends BaseModel
         return $result;
     }
 
+    /**
+     * v6.6 — Detect language preference for a LINE user from their most
+     * recent inbound text message. Returns 'th' if Thai script appears,
+     * 'en' if a non-Thai text message exists, or null when the user has
+     * no text history.
+     *
+     * Used by postback handlers (e.g. carousel "Book this") to figure
+     * out which language the user is currently using when the postback
+     * data itself doesn't carry it (legacy carousels rendered before
+     * v6.6 #150). Far more reliable than guessing from display_name,
+     * which fails for Thai users with English-spelled names.
+     */
+    public function getRecentLanguage(int $companyId, int $lineUserDbId): ?string
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT content FROM line_messages
+             WHERE company_id = ?
+               AND line_user_id = ?
+               AND direction = 'inbound'
+               AND message_type = 'text'
+             ORDER BY id DESC
+             LIMIT 1"
+        );
+        $stmt->bind_param('ii', $companyId, $lineUserDbId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$row) return null;
+        $content = (string)($row['content'] ?? '');
+        if ($content === '') return null;
+        return preg_match('/[\x{0E00}-\x{0E7F}]/u', $content) ? 'th' : 'en';
+    }
+
     public function getLineUserById(int $id): ?array
     {
         $stmt = $this->conn->prepare("SELECT * FROM line_users WHERE id = ?");

--- a/app/Models/LineOA.php
+++ b/app/Models/LineOA.php
@@ -164,12 +164,28 @@ class LineOA extends BaseModel
      */
     public function getAgentBindings(int $companyId): array
     {
+        // #136: relaxed the `a.company_id = u.company_id` constraint so
+        // agent-tenant bindings (where the bound authorize user lives in a
+        // partner agent's tenant) display correctly. The bind action still
+        // enforces the partner-relationship via tour_agent_profiles, so this
+        // JOIN doesn't grant access — it only renders what's already valid.
+        // The agent partner's company name (when applicable) is fetched via
+        // a second LEFT JOIN through the partner registration so the UI can
+        // label which company a binding belongs to.
         $stmt = $this->conn->prepare(
             "SELECT u.id, u.line_user_id, u.display_name, u.picture_url, u.user_type,
                     u.linked_user_id, u.linked_at, u.linked_by,
-                    a.email AS linked_email, a.name AS linked_name, a.level AS linked_level
+                    a.email AS linked_email, a.name AS linked_name, a.level AS linked_level,
+                    a.company_id AS linked_user_com_id,
+                    partner.name_en AS partner_company_en,
+                    partner.name_th AS partner_company_th
              FROM line_users u
-             LEFT JOIN authorize a ON a.id = u.linked_user_id AND a.company_id = u.company_id
+             LEFT JOIN authorize a ON a.id = u.linked_user_id
+             LEFT JOIN tour_agent_profiles tap
+                    ON tap.company_ref_id = a.company_id
+                   AND tap.company_id     = u.company_id
+                   AND tap.deleted_at IS NULL
+             LEFT JOIN company partner ON partner.id = tap.company_ref_id
              WHERE u.company_id = ? AND u.deleted_at IS NULL
              ORDER BY (u.user_type = 'agent') DESC, u.display_name ASC"
         );
@@ -182,6 +198,7 @@ class LineOA extends BaseModel
 
     /**
      * v6.3 #120 — List iACC users in this company eligible to be bound as agents.
+     * "My Team" mode — operator's own employees.
      */
     public function getEligibleIaccUsers(int $companyId): array
     {
@@ -197,19 +214,93 @@ class LineOA extends BaseModel
     }
 
     /**
+     * v6.3 #136 — List authorize users from agent-partner tenants for this
+     * operator. "Agent Partners" mode — employees of B2B partners that are
+     * registered with this operator via tour_agent_profiles.
+     *
+     * Each row includes the agent company's display labels (name_en/name_th)
+     * so the bind UI can label the dropdown clearly. Filters out agents with
+     * an expired contract (contract_end < CURDATE()) so admins don't bind to
+     * relationships that no longer exist.
+     */
+    public function getEligibleAgentTenantUsers(int $operatorCompanyId): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT a.id, a.name, a.email, a.level,
+                    a.company_id   AS user_com_id,
+                    c.name_en      AS agent_company_en,
+                    c.name_th      AS agent_company_th,
+                    tap.id         AS agent_profile_id
+             FROM authorize a
+             JOIN tour_agent_profiles tap
+               ON tap.company_ref_id = a.company_id
+              AND tap.deleted_at IS NULL
+             JOIN company c
+               ON c.id = a.company_id
+             WHERE tap.company_id = ?
+               AND (tap.contract_end IS NULL OR tap.contract_end >= CURDATE())
+             ORDER BY c.name_en ASC, a.level DESC, a.name ASC"
+        );
+        $stmt->bind_param('i', $operatorCompanyId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    /**
+     * v6.3 #136 — Resolve a tour_agent_profiles.id from the bound iACC user.
+     *
+     * Returns the agent profile id if the user belongs to a partner agent
+     * tenant registered with this operator. Returns null if the user is in
+     * the operator's own tenant (own-team / sales rep — agent_id stays null)
+     * or if no matching profile is found.
+     */
+    public function resolveAgentIdFromBoundUser(int $operatorCompanyId, int $boundUserComId): ?int
+    {
+        if ($boundUserComId === $operatorCompanyId) return null; // own-team — not a partner agent
+        $stmt = $this->conn->prepare(
+            "SELECT id FROM tour_agent_profiles
+             WHERE company_id = ?
+               AND company_ref_id = ?
+               AND deleted_at IS NULL
+             ORDER BY id ASC
+             LIMIT 1"
+        );
+        $stmt->bind_param('ii', $operatorCompanyId, $boundUserComId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ? (int)$row['id'] : null;
+    }
+
+    /**
      * v6.3 #120 — Bind a LINE user (must be user_type='agent') to an iACC user.
-     * Returns true on success, false if either user belongs to a different company
-     * or the LINE user is not an agent.
+     *
+     * v6.3 #136 — Auth check expanded: the iACC user must be EITHER
+     *   (a) in the operator's own tenant (operator employee / sales rep), OR
+     *   (b) in a tenant whose company_id appears in tour_agent_profiles.company_ref_id
+     *       for this operator (agent partner employee).
+     *
+     * Returns true on success, false if the line_user isn't in this tenant /
+     * isn't user_type='agent', or the iACC user isn't reachable from this
+     * operator under either rule.
      */
     public function bindAgentToUser(int $companyId, int $lineUserDbId, int $iaccUserId, int $adminId): bool
     {
-        // Verify both rows belong to this tenant + the LINE user is an agent
         $check = $this->conn->prepare(
             "SELECT
-                (SELECT COUNT(*) FROM line_users WHERE id = ? AND company_id = ? AND user_type = 'agent' AND deleted_at IS NULL) AS lu_ok,
-                (SELECT COUNT(*) FROM authorize  WHERE id = ? AND company_id = ?) AS au_ok"
+                (SELECT COUNT(*) FROM line_users
+                 WHERE id = ? AND company_id = ? AND user_type = 'agent' AND deleted_at IS NULL) AS lu_ok,
+                (SELECT COUNT(*) FROM authorize a
+                 WHERE a.id = ?
+                   AND (a.company_id = ?
+                        OR a.company_id IN (
+                            SELECT company_ref_id FROM tour_agent_profiles
+                            WHERE company_id = ? AND deleted_at IS NULL
+                        ))) AS au_ok"
         );
-        $check->bind_param('iiii', $lineUserDbId, $companyId, $iaccUserId, $companyId);
+        $check->bind_param('iiiii', $lineUserDbId, $companyId, $iaccUserId, $companyId, $companyId);
         $check->execute();
         $row = $check->get_result()->fetch_assoc();
         $check->close();
@@ -288,8 +379,13 @@ class LineOA extends BaseModel
      */
     public function getBoundUserDetails(int $companyId, string $lineUserIdStr): ?array
     {
+        // user_com_id is added in #136 so callers can pass it to
+        // resolveAgentIdFromBoundUser() — when the bound user belongs to an
+        // agent tenant (different company_id), we resolve to the operator's
+        // tour_agent_profiles row instead of treating them as an own-team rep.
         $stmt = $this->conn->prepare(
-            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email, a.phone
+            "SELECT a.id AS authorize_id, a.name AS authorize_name, a.email, a.phone,
+                    a.company_id AS user_com_id
              FROM line_users u
              JOIN authorize a ON a.id = u.linked_user_id
              WHERE u.company_id = ?

--- a/app/Models/ProductModel.php
+++ b/app/Models/ProductModel.php
@@ -138,7 +138,7 @@ class ProductModel extends BaseModel
             $sql .= " AND brand.company_id = '" . \sql_int($companyId) . "'";
         }
         $sql .= " ORDER BY brand.brand_name";
-        
+
         $result = mysqli_query($this->conn, $sql);
         $items = [];
         if ($result) {
@@ -147,5 +147,57 @@ class ProductModel extends BaseModel
             }
         }
         return $items;
+    }
+
+    /**
+     * v6.6 — list models eligible to be a "parent" in the parent_model_id
+     * dropdown. Two-level hierarchy only: parents are themselves top-level
+     * (parent_model_id IS NULL), so a model never has a chain of ancestors.
+     *
+     * Excludes the current row when editing so a model can't pick itself
+     * as its own parent.
+     */
+    public function getParentOptions(int $excludeId = 0): array
+    {
+        $companyId = intval($_SESSION['com_id'] ?? 0);
+        $excludeId = intval($excludeId);
+        $sql = "SELECT id, model_name FROM model
+                WHERE company_id = " . \sql_int($companyId) . "
+                  AND deleted_at IS NULL
+                  AND parent_model_id IS NULL";
+        if ($excludeId > 0) {
+            $sql .= " AND id != " . \sql_int($excludeId);
+        }
+        $sql .= " ORDER BY model_name";
+        $result = mysqli_query($this->conn, $sql);
+        $rows = [];
+        while ($result && $row = mysqli_fetch_assoc($result)) {
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    /**
+     * v6.6 — fetch active sub-models of a parent. Used by
+     * LineAgentController to auto-seed line items when the parent tour
+     * is booked — each child becomes one item_type='entrance' (or
+     * configurable later) row in tour_booking_items.
+     */
+    public function getChildModels(int $parentId, int $companyId): array
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT id, model_name, des, price, type_id
+             FROM model
+             WHERE company_id = ?
+               AND parent_model_id = ?
+               AND deleted_at IS NULL
+               AND is_active = 1
+             ORDER BY id ASC"
+        );
+        $stmt->bind_param('ii', $companyId, $parentId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
     }
 }

--- a/app/Models/ProductModel.php
+++ b/app/Models/ProductModel.php
@@ -161,7 +161,10 @@ class ProductModel extends BaseModel
     {
         $companyId = intval($_SESSION['com_id'] ?? 0);
         $excludeId = intval($excludeId);
-        $sql = "SELECT id, model_name FROM model
+        // `des` included so the dropdown can show "SM-IT-01-ST — Ang Thong
+        // Marine Park One-Day Trip" instead of just the code. Helpful for
+        // admins who don't have the model_name → tour mapping memorized.
+        $sql = "SELECT id, model_name, des FROM model
                 WHERE company_id = " . \sql_int($companyId) . "
                   AND deleted_at IS NULL
                   AND parent_model_id IS NULL";

--- a/app/Services/LineTemplateRenderer.php
+++ b/app/Services/LineTemplateRenderer.php
@@ -1,0 +1,165 @@
+<?php
+namespace App\Services;
+
+/**
+ * LineTemplateRenderer — v6.4 #133
+ *
+ * Per-tenant template rendering for LINE OA reply text. Reads from the
+ * `line_message_templates` table (created by v6.2 LINE OA Rich Messaging,
+ * catch-up migration in v6.4); falls back to hardcoded defaults when a
+ * template is missing or fails to render.
+ *
+ * v1 scope (this PR) — plain-text replies only:
+ *   - agent.tour_not_found  → "ไม่พบทัวร์ที่ตรงกับ ..."
+ *   - agent.tour_ambiguous  → "พบทัวร์หลายรายการที่ตรงกัน: ..."
+ *   - agent.write_failed    → "เกิดข้อผิดพลาดในการบันทึก ..."
+ *   - legacy.book_redirect  → "กรุณาใช้แบบฟอร์มการจองใหม่ ..."
+ *
+ * Future scope (Phase 2): the success/error Flex bubbles. They have
+ * conditional rows (email line only when email present, etc.) that
+ * require a richer template format than plain string substitution.
+ *
+ * Placeholder syntax: `{{name}}` — Mustache-style, friendly for admin
+ * editors. Substitution is a simple str_replace pre-render. Missing
+ * placeholders are left as `{{name}}` literally (visible to user, makes
+ * misconfiguration loud rather than silent).
+ *
+ * Usage:
+ *
+ *   $text = LineTemplateRenderer::renderText(
+ *       $companyId,
+ *       'agent.tour_not_found',
+ *       'th',
+ *       ['tour_name' => 'SM-EN-01-AT']
+ *   );
+ *
+ * Lookup order:
+ *   1. line_message_templates row (per-tenant, by name)
+ *   2. Hardcoded default in self::DEFAULTS (this file)
+ *
+ * The "lazy seed" pattern (insert the default into the tenant's table on
+ * first miss) is intentionally NOT done here — it would create a row that
+ * looks like an admin override even though the admin never edited it. The
+ * existing template-edit.php page lets admins create/edit per-tenant
+ * customizations explicitly when they want to.
+ */
+class LineTemplateRenderer
+{
+    /**
+     * Hardcoded defaults — single source of truth when no per-tenant
+     * customization exists. Each key is the canonical template name; each
+     * value carries the bilingual TH+EN content and a sample list of
+     * placeholder names (informational, used by the editor's help panel).
+     */
+    private const DEFAULTS = [
+        'agent.tour_not_found' => [
+            'message_type' => 'text',
+            'th'           => 'ไม่พบทัวร์ที่ตรงกับ "{{tour_name}}" ในระบบ',
+            'en'           => 'No tour matching "{{tour_name}}" found in your system.',
+            'placeholders' => ['tour_name'],
+        ],
+        'agent.tour_ambiguous' => [
+            'message_type' => 'text',
+            'th'           => "พบทัวร์หลายรายการที่ตรงกัน:\n{{candidates}}กรุณาส่งใหม่พร้อมระบุชื่อให้ชัดเจนยิ่งขึ้น",
+            'en'           => "Multiple tours matched:\n{{candidates}}Please re-send with a more specific name.",
+            'placeholders' => ['candidates'],
+        ],
+        'agent.write_failed' => [
+            'message_type' => 'text',
+            'th'           => 'เกิดข้อผิดพลาดในการบันทึก กรุณาติดต่อผู้ดูแลระบบ',
+            'en'           => 'Could not save the booking. Please contact your admin.',
+            'placeholders' => [],
+        ],
+        'legacy.book_redirect' => [
+            'message_type' => 'text',
+            'th'           => "กรุณาใช้แบบฟอร์มการจองใหม่ — พิมพ์ \"จองทัวร์\" พร้อมรายละเอียด เช่น:\n\nจองทัวร์\nทัวร์: <ชื่อทัวร์>\nวันที่: {{sample_date}}\nผู้ใหญ่: <จำนวน>\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>",
+            'en'           => "Please use the new booking template — start your message with \"book tour\" and include the tour details, e.g.:\n\nbook tour\ntour: <tour name>\ndate: {{sample_date}}\nadults: <count>\ncustomer: <name>\nmobile: <phone>",
+            'placeholders' => ['sample_date'],
+        ],
+    ];
+
+    /**
+     * Render a plain-text template for the given tenant + name + language,
+     * substituting `{{placeholders}}`.
+     *
+     * Returns the rendered string. Never throws — failures are logged and
+     * the hardcoded default is rendered instead, so the customer-facing
+     * reply path is never broken by a misconfigured template.
+     */
+    public static function renderText(int $companyId, string $name, string $lang, array $vars = []): string
+    {
+        $lang = ($lang === 'th') ? 'th' : 'en';
+        $template = self::lookup($companyId, $name, $lang);
+
+        // Substitute placeholders. Missing keys are intentionally left as
+        // literal `{{name}}` so misconfiguration is loud rather than silent.
+        $rendered = $template;
+        foreach ($vars as $k => $v) {
+            $rendered = str_replace('{{' . $k . '}}', (string)$v, $rendered);
+        }
+        return $rendered;
+    }
+
+    /**
+     * Look up the per-tenant template content for one language. Falls
+     * back to the hardcoded default in self::DEFAULTS when:
+     *   - The line_message_templates row is missing (most common case)
+     *   - The row's content for the requested language is empty/null
+     *   - Any DB error fires (logged, then fallback)
+     */
+    private static function lookup(int $companyId, string $name, string $lang): string
+    {
+        $default = self::DEFAULTS[$name] ?? null;
+        $defaultContent = $default[$lang] ?? '';
+
+        // No DB connection available (e.g. unit-testing the renderer in
+        // isolation) — short-circuit to defaults.
+        global $db;
+        if (!isset($db) || !is_object($db) || !isset($db->conn)) {
+            return $defaultContent;
+        }
+
+        try {
+            $stmt = $db->conn->prepare(
+                "SELECT content_th, content_en FROM line_message_templates
+                 WHERE company_id = ? AND name = ?
+                   AND is_active = 1
+                   AND deleted_at IS NULL
+                 ORDER BY id DESC
+                 LIMIT 1"
+            );
+            $stmt->bind_param('is', $companyId, $name);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            if ($row) {
+                $col = ($lang === 'th') ? 'content_th' : 'content_en';
+                $val = trim((string)($row[$col] ?? ''));
+                if ($val !== '') return $val;
+            }
+        } catch (\Throwable $e) {
+            error_log('LineTemplateRenderer::lookup failed for company ' . $companyId
+                . ' name ' . $name . ' — falling back to default: ' . $e->getMessage());
+        }
+
+        return $defaultContent;
+    }
+
+    /**
+     * List the canonical template names so the editor UI (in v6.4 #133
+     * Phase 2) can show admins what's available to customize. Read by
+     * the templates index page if/when we wire it up.
+     */
+    public static function listKnownTemplates(): array
+    {
+        $out = [];
+        foreach (self::DEFAULTS as $name => $meta) {
+            $out[$name] = [
+                'message_type' => $meta['message_type'],
+                'placeholders' => $meta['placeholders'] ?? [],
+            ];
+        }
+        return $out;
+    }
+}

--- a/app/Services/LineTourCatalog.php
+++ b/app/Services/LineTourCatalog.php
@@ -1,0 +1,245 @@
+<?php
+namespace App\Services;
+
+/**
+ * LineTourCatalog — v6.6 #135
+ *
+ * Builds the Flex carousel of available tours and the pre-filled
+ * booking template that gets sent back when a user taps a "Book this"
+ * button. The browse → tap → reply flow is the discoverability layer
+ * on top of the structured booking template (#120, #132, #134) so
+ * customers and agents don't have to memorize tour codes like
+ * "SM-EN-01-AT".
+ *
+ * Flow:
+ *   User sends   "ดูทัวร์" / "show tours"  (any of the configured triggers)
+ *   Bot replies  Flex carousel of up to N tours, each with a Book button
+ *   User taps    Book this → LINE postback action=prefill_booking&tour_id=X
+ *   Bot replies  pre-filled text template with the chosen tour name
+ *   User edits   completes the rest (date, pax, contact) and sends
+ *   Existing     #134 flow handles the booking write
+ *
+ * Defers (out of scope for v1):
+ *   - model.is_customer_bookable flag (filter customer-facing list)
+ *   - model.thumbnail_url (use default placeholder until populated)
+ *   - Pagination via "See more" CTA bubble (cap at 10 for now)
+ *   - Per-tenant trigger phrases (use a fixed bilingual list)
+ */
+class LineTourCatalog
+{
+    /**
+     * Bilingual triggers that activate the carousel browse. Case-insensitive.
+     * If a message starts with any of these, fire the carousel before the
+     * agent booking intercept tries to parse it as a booking.
+     */
+    private const TRIGGERS = [
+        'ดูทัวร์', 'รายการทัวร์', 'ทัวร์ทั้งหมด',
+        'show tours', 'tour list', 'tours', 'list tours', 'catalog',
+    ];
+
+    /**
+     * Maximum bubbles per carousel. LINE Flex caps at 12; we use 10 to
+     * leave room for a future "See more" CTA bubble.
+     */
+    private const MAX_BUBBLES = 10;
+
+    /**
+     * Returns true if the inbound message text matches any browse trigger.
+     */
+    public static function isTriggered(string $message): bool
+    {
+        $haystack = mb_strtolower(trim($message));
+        foreach (self::TRIGGERS as $trigger) {
+            if (mb_stripos($haystack, mb_strtolower($trigger)) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Build a Flex carousel of active tours for the operator. Returns the
+     * complete LINE Messaging API message envelope (type=flex, altText,
+     * contents=carousel).
+     *
+     * If the operator has no active tours, returns a plain-text "no tours
+     * available" message instead (also bilingual).
+     */
+    public static function buildCarousel(int $companyId, string $lang = 'en'): array
+    {
+        $isThai = ($lang === 'th');
+        $tours  = self::fetchActiveTours($companyId, self::MAX_BUBBLES);
+
+        if (empty($tours)) {
+            return [
+                'type' => 'text',
+                'text' => $isThai
+                    ? 'ขณะนี้ยังไม่มีทัวร์ที่เปิดให้จอง กรุณาตรวจสอบอีกครั้งภายหลัง'
+                    : 'No tours available right now — please check back later.',
+            ];
+        }
+
+        $bubbles = [];
+        foreach ($tours as $t) {
+            $bubbles[] = self::buildBubble($t, $isThai);
+        }
+
+        return [
+            'type'    => 'flex',
+            'altText' => $isThai
+                ? 'รายการทัวร์ที่เปิดให้จอง'
+                : 'Available tours — tap a card to start booking',
+            'contents' => [
+                'type'     => 'carousel',
+                'contents' => $bubbles,
+            ],
+        ];
+    }
+
+    /**
+     * Build a pre-filled booking template for the chosen tour. Sent in
+     * response to the postback action=prefill_booking&tour_id=X.
+     *
+     * The user will receive this text and need to fill in the remaining
+     * fields (date, pax, customer info) before sending it back. Existing
+     * #134 booking flow handles the write.
+     *
+     * Returns plain-text reply (one LINE message). Returns null if the
+     * tour was not found or doesn't belong to the operator (defensive
+     * tenancy check).
+     */
+    public static function buildPrefillReply(int $companyId, int $tourId, string $lang = 'en'): ?array
+    {
+        $tour = self::fetchTour($companyId, $tourId);
+        if (!$tour) return null;
+
+        $isThai = ($lang === 'th');
+        $sampleDate = date('Y-m-d', strtotime('+7 days'));
+        $tourName   = $tour['model_name'];
+
+        $text = $isThai
+            ? "เริ่มการจองทัวร์ \"{$tourName}\"\nกรุณาส่งข้อความตามรูปแบบด้านล่าง พร้อมกรอกข้อมูลให้ครบ:\n\n"
+              . "จองทัวร์\nทัวร์: {$tourName}\nวันที่: {$sampleDate}\nผู้ใหญ่: <จำนวน>\nเด็ก: 0\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>\nอีเมล: <อีเมล (ถ้ามี)>"
+            : "Starting booking for \"{$tourName}\"\nPlease send back the template below with the remaining details filled in:\n\n"
+              . "book tour\ntour: {$tourName}\ndate: {$sampleDate}\nadults: <count>\nchildren: 0\ncustomer: <name>\nmobile: <phone>\nemail: <email (optional)>";
+
+        return ['type' => 'text', 'text' => $text];
+    }
+
+    // ============================================================
+    // Internals
+    // ============================================================
+
+    /**
+     * Fetch active tours for the operator. Joins type for the category
+     * label. Tenancy enforced via company_id.
+     */
+    private static function fetchActiveTours(int $companyId, int $limit): array
+    {
+        global $db;
+        $stmt = $db->conn->prepare(
+            "SELECT m.id, m.model_name, m.des, m.price,
+                    t.name AS type_name
+             FROM model m
+             LEFT JOIN type t ON m.type_id = t.id
+             WHERE m.company_id = ?
+               AND m.deleted_at IS NULL
+               AND m.is_active = 1
+             ORDER BY t.name ASC, m.model_name ASC
+             LIMIT ?"
+        );
+        $stmt->bind_param('ii', $companyId, $limit);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
+    }
+
+    /**
+     * Fetch a single tour by id, scoped to the operator. Defensive
+     * against postback tampering (a malicious user editing the
+     * data= URL to point at another tenant's tour id).
+     */
+    private static function fetchTour(int $companyId, int $tourId): ?array
+    {
+        global $db;
+        $stmt = $db->conn->prepare(
+            "SELECT m.id, m.model_name, m.des, m.price
+             FROM model m
+             WHERE m.company_id = ?
+               AND m.id = ?
+               AND m.deleted_at IS NULL
+               AND m.is_active = 1
+             LIMIT 1"
+        );
+        $stmt->bind_param('ii', $companyId, $tourId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ?: null;
+    }
+
+    /**
+     * Build a single Flex bubble for one tour.
+     *
+     * Layout:
+     *   - Header: type/category name (small, muted)
+     *   - Body: model_name (bold, larger), description preview, price line
+     *   - Footer: "Book this" postback button
+     */
+    private static function buildBubble(array $tour, bool $isThai): array
+    {
+        $title       = (string)($tour['model_name'] ?? '');
+        $category    = (string)($tour['type_name']  ?? '');
+        $description = trim(strip_tags((string)($tour['des'] ?? '')));
+        if (mb_strlen($description) > 80) {
+            $description = mb_substr($description, 0, 80) . '…';
+        }
+        $price = floatval($tour['price'] ?? 0);
+        $priceLabel = $price > 0
+            ? '฿' . number_format($price, 0) . ($isThai ? ' / ท่าน' : ' / pax')
+            : ($isThai ? 'สอบถามราคา' : 'Contact for price');
+
+        $bookLabel = $isThai ? '📝 จองทัวร์นี้' : '📝 Book this';
+
+        $bodyContents = [];
+        if ($category !== '') {
+            $bodyContents[] = ['type' => 'text', 'text' => $category, 'size' => 'xs', 'color' => '#888888'];
+        }
+        $bodyContents[] = ['type' => 'text', 'text' => $title, 'weight' => 'bold', 'size' => 'lg', 'wrap' => true, 'margin' => 'sm'];
+        if ($description !== '') {
+            $bodyContents[] = ['type' => 'text', 'text' => $description, 'size' => 'sm', 'color' => '#666666', 'wrap' => true, 'margin' => 'md'];
+        }
+        $bodyContents[] = ['type' => 'separator', 'margin' => 'md'];
+        $bodyContents[] = ['type' => 'text', 'text' => $priceLabel, 'weight' => 'bold', 'size' => 'md', 'color' => '#06C755', 'margin' => 'md'];
+
+        return [
+            'type' => 'bubble',
+            'size' => 'kilo',
+            'body' => [
+                'type'     => 'box',
+                'layout'   => 'vertical',
+                'contents' => $bodyContents,
+            ],
+            'footer' => [
+                'type'   => 'box',
+                'layout' => 'vertical',
+                'contents' => [
+                    [
+                        'type'   => 'button',
+                        'style'  => 'primary',
+                        'color'  => '#06C755',
+                        'action' => [
+                            'type'  => 'postback',
+                            'label' => $bookLabel,
+                            // displayText shows in the chat as if the user typed
+                            // it — gives them a record of which tour they picked.
+                            'displayText' => ($isThai ? 'จองทัวร์: ' : 'Book: ') . $title,
+                            'data'  => 'action=prefill_booking&tour_id=' . intval($tour['id']),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Services/LineTourCatalog.php
+++ b/app/Services/LineTourCatalog.php
@@ -168,6 +168,11 @@ class LineTourCatalog
     private static function fetchActiveTours(int $companyId, int $limit): array
     {
         global $db;
+        // The `parent_model_id IS NULL` filter (added in v6.6 sub-model
+        // support) ensures only top-level tours appear in the carousel —
+        // sub-items like entrance fees are children of their parent tour
+        // and get auto-seeded as line items at booking time, never browsed
+        // standalone by customers.
         $stmt = $db->conn->prepare(
             "SELECT m.id, m.model_name, m.des, m.price,
                     t.name AS type_name
@@ -177,6 +182,7 @@ class LineTourCatalog
                AND m.deleted_at IS NULL
                AND m.is_active = 1
                AND m.is_customer_bookable = 1
+               AND m.parent_model_id IS NULL
              ORDER BY t.name ASC, m.model_name ASC
              LIMIT ?"
         );

--- a/app/Services/LineTourCatalog.php
+++ b/app/Services/LineTourCatalog.php
@@ -117,11 +117,36 @@ class LineTourCatalog
         $sampleDate = date('Y-m-d', strtotime('+7 days'));
         $tourName   = $tour['model_name'];
 
+        // Expanded in the v6.6 #135 follow-up to include all parser-supported
+        // optional fields (hotel, room, messenger, notes) so users discover
+        // them rather than missing pickup-relevant info on first send.
         $text = $isThai
-            ? "เริ่มการจองทัวร์ \"{$tourName}\"\nกรุณาส่งข้อความตามรูปแบบด้านล่าง พร้อมกรอกข้อมูลให้ครบ:\n\n"
-              . "จองทัวร์\nทัวร์: {$tourName}\nวันที่: {$sampleDate}\nผู้ใหญ่: <จำนวน>\nเด็ก: 0\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>\nอีเมล: <อีเมล (ถ้ามี)>"
-            : "Starting booking for \"{$tourName}\"\nPlease send back the template below with the remaining details filled in:\n\n"
-              . "book tour\ntour: {$tourName}\ndate: {$sampleDate}\nadults: <count>\nchildren: 0\ncustomer: <name>\nmobile: <phone>\nemail: <email (optional)>";
+            ? "เริ่มการจองทัวร์ \"{$tourName}\"\nกรุณาส่งข้อความตามรูปแบบด้านล่าง พร้อมกรอกข้อมูลให้ครบ (ฟิลด์ที่มี * เป็นข้อมูลที่จำเป็น):\n\n"
+              . "จองทัวร์\n"
+              . "ทัวร์: {$tourName}\n"
+              . "วันที่: {$sampleDate} *\n"
+              . "ผู้ใหญ่: <จำนวน> *\n"
+              . "เด็ก: 0\n"
+              . "ลูกค้า: <ชื่อ> *\n"
+              . "มือถือ: <เบอร์> *\n"
+              . "อีเมล: <อีเมล (ถ้ามี)>\n"
+              . "เมสเซนเจอร์: <line:id หรือ @page (ถ้ามี)>\n"
+              . "ที่พัก: <ชื่อโรงแรม/ที่พัก (ถ้ามี)>\n"
+              . "หมายเลขห้อง: <เลขห้อง (ถ้ามี)>\n"
+              . "หมายเหตุ: <รายละเอียดเพิ่มเติม (ถ้ามี)>"
+            : "Starting booking for \"{$tourName}\"\nPlease send back the template below with the remaining details filled in (* = required):\n\n"
+              . "book tour\n"
+              . "tour: {$tourName}\n"
+              . "date: {$sampleDate} *\n"
+              . "adults: <count> *\n"
+              . "children: 0\n"
+              . "customer: <name> *\n"
+              . "mobile: <phone> *\n"
+              . "email: <email (optional)>\n"
+              . "messenger: <line:id or @page (optional)>\n"
+              . "accommodation: <hotel/villa name (optional)>\n"
+              . "room: <room number (optional)>\n"
+              . "notes: <extra details (optional)>";
 
         return ['type' => 'text', 'text' => $text];
     }
@@ -131,8 +156,14 @@ class LineTourCatalog
     // ============================================================
 
     /**
-     * Fetch active tours for the operator. Joins type for the category
-     * label. Tenancy enforced via company_id.
+     * Fetch active, customer-bookable tours for the operator. Joins type
+     * for the category label. Tenancy enforced via company_id.
+     *
+     * The is_customer_bookable filter (added in the v6.6 #135 follow-up)
+     * lets operators hide non-tour rows like entrance fees from the
+     * customer-facing catalog while keeping them otherwise active for
+     * pricing/reporting. Default for new and existing rows is 1
+     * (visible) — operators flip specific rows to 0 to hide them.
      */
     private static function fetchActiveTours(int $companyId, int $limit): array
     {
@@ -145,6 +176,7 @@ class LineTourCatalog
              WHERE m.company_id = ?
                AND m.deleted_at IS NULL
                AND m.is_active = 1
+               AND m.is_customer_bookable = 1
              ORDER BY t.name ASC, m.model_name ASC
              LIMIT ?"
         );

--- a/app/Services/LineTourCatalog.php
+++ b/app/Services/LineTourCatalog.php
@@ -81,7 +81,7 @@ class LineTourCatalog
 
         $bubbles = [];
         foreach ($tours as $t) {
-            $bubbles[] = self::buildBubble($t, $isThai);
+            $bubbles[] = self::buildBubble($t, $isThai, $lang);
         }
 
         return [
@@ -225,7 +225,7 @@ class LineTourCatalog
      *   - Body: model_name (bold, larger), description preview, price line
      *   - Footer: "Book this" postback button
      */
-    private static function buildBubble(array $tour, bool $isThai): array
+    private static function buildBubble(array $tour, bool $isThai, string $lang = 'en'): array
     {
         $title       = (string)($tour['model_name'] ?? '');
         $category    = (string)($tour['type_name']  ?? '');
@@ -273,7 +273,12 @@ class LineTourCatalog
                             // displayText shows in the chat as if the user typed
                             // it — gives them a record of which tour they picked.
                             'displayText' => ($isThai ? 'จองทัวร์: ' : 'Book: ') . $title,
-                            'data'  => 'action=prefill_booking&tour_id=' . intval($tour['id']),
+                            // Carry the carousel's language back through
+                            // the postback so the prefill reply matches —
+                            // detecting from display_name is unreliable
+                            // (Thai users with English-spelled names
+                            // would land on the wrong template).
+                            'data'  => 'action=prefill_booking&tour_id=' . intval($tour['id']) . '&lang=' . ($lang === 'th' ? 'th' : 'en'),
                         ],
                     ],
                 ],

--- a/app/Views/line-oa/agent-bindings.php
+++ b/app/Views/line-oa/agent-bindings.php
@@ -22,6 +22,9 @@ $labels = [
         'step2'        => '2. Open the <a href="index.php?page=line_users">Users</a> page and change their <strong>user_type</strong> to <strong>agent</strong>.',
         'step3'        => '3. Return here and bind their LINE account to an iACC user.',
         'unbound'      => '— not bound —',
+        'tab_team'     => 'My Team',
+        'tab_partners' => 'Agent Partners',
+        'no_partners'  => 'No registered agent partners with active contracts for this operator. Set them up from the Tour Agent registration screen first.',
     ],
     'th' => [
         'page_title'   => 'ผูกบัญชีตัวแทน',
@@ -42,11 +45,21 @@ $labels = [
         'step2'        => '2. ไปที่หน้า <a href="index.php?page=line_users">Users</a> แล้วเปลี่ยน <strong>user_type</strong> เป็น <strong>agent</strong>',
         'step3'        => '3. กลับมาที่หน้านี้เพื่อผูกบัญชีกับผู้ใช้ iACC',
         'unbound'      => '— ยังไม่ผูก —',
+        'tab_team'     => 'ทีมของฉัน',
+        'tab_partners' => 'ตัวแทนพันธมิตร',
+        'no_partners'  => 'ยังไม่มีตัวแทนพันธมิตรที่มีสัญญาใช้งานอยู่ กรุณาลงทะเบียนตัวแทนในหน้า Tour Agent ก่อน',
     ],
 ];
 $t = $labels[$lang];
 
 $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] ?? '') === 'agent'));
+
+// #136: scope toggle — "team" (operator's own employees) vs "partners"
+// (employees of B2B partner agents registered with this operator).
+$scope = ($scope ?? 'team') === 'partners' ? 'partners' : 'team';
+$activeUsers = $scope === 'partners'
+    ? ($agentTenantUsers ?? [])
+    : ($iaccUsers ?? []);
 ?>
 <?php $currentNavPage = 'line_agent_bindings'; include __DIR__ . '/_nav.php'; ?>
 
@@ -57,12 +70,27 @@ $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] 
 <div class="alert alert-danger alert-dismissible"><button type="button" class="close" data-dismiss="alert">&times;</button><?= htmlspecialchars($_SESSION['flash_error'], ENT_QUOTES, 'UTF-8') ?></div>
 <?php unset($_SESSION['flash_error']); endif; ?>
 
+<div style="margin-bottom: 15px;">
+    <div class="btn-group" role="tablist">
+        <a href="index.php?page=line_agent_bindings&scope=team" class="btn btn-sm btn-<?= $scope === 'team' ? 'primary' : 'default' ?>">
+            <i class="fa fa-users"></i> <?= $t['tab_team'] ?>
+        </a>
+        <a href="index.php?page=line_agent_bindings&scope=partners" class="btn btn-sm btn-<?= $scope === 'partners' ? 'primary' : 'default' ?>">
+            <i class="fa fa-handshake-o"></i> <?= $t['tab_partners'] ?>
+        </a>
+    </div>
+</div>
+
 <div style="display:flex; gap:20px; flex-wrap:wrap;">
 
 <div style="flex:2; min-width:380px;">
     <div style="background:white; border-radius:12px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
         <h4 style="margin-top:0;"><i class="fa fa-link"></i> <?= $t['agent_users'] ?></h4>
         <p style="color:#666;"><?= $t['intro'] ?></p>
+
+        <?php if ($scope === 'partners' && empty($activeUsers)): ?>
+            <div class="alert alert-warning" style="margin:10px 0;"><?= $t['no_partners'] ?></div>
+        <?php endif; ?>
 
         <?php if (empty($agents)): ?>
             <p style="text-align:center; padding:30px 20px; color:#999;"><?= $t['no_agents'] ?></p>
@@ -94,6 +122,17 @@ $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] 
                                     <i class="fa fa-check"></i>
                                     <?= htmlspecialchars($a['linked_name'] ?: $a['linked_email'] ?: ('#' . $a['linked_user_id']), ENT_QUOTES, 'UTF-8') ?>
                                 </span>
+                                <?php
+                                // #136: when the bound user lives in an agent-partner tenant,
+                                // show the partner company name underneath so the admin can
+                                // see at a glance which agent this binding is attributed to.
+                                $partnerLabel = $isThai
+                                    ? ($a['partner_company_th'] ?? $a['partner_company_en'] ?? '')
+                                    : ($a['partner_company_en'] ?? $a['partner_company_th'] ?? '');
+                                ?>
+                                <?php if (!empty($partnerLabel)): ?>
+                                    <small class="text-muted" style="display:block;"><i class="fa fa-handshake-o"></i> <?= htmlspecialchars($partnerLabel, ENT_QUOTES, 'UTF-8') ?></small>
+                                <?php endif; ?>
                                 <?php if (!empty($a['linked_at'])): ?>
                                     <small class="text-muted" style="display:block;"><?= date('M d, Y', strtotime($a['linked_at'])) ?></small>
                                 <?php endif; ?>
@@ -105,11 +144,24 @@ $agents = array_values(array_filter($bindings ?? [], fn($r) => ($r['user_type'] 
                             <form method="POST" action="index.php?page=line_agent_bind_save" style="display:inline-flex; gap:5px; align-items:center;">
                                 <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
                                 <input type="hidden" name="line_user_id" value="<?= (int)$a['id'] ?>">
-                                <select name="iacc_user_id" class="form-control input-sm" style="max-width:180px;">
+                                <select name="iacc_user_id" class="form-control input-sm" style="max-width:220px;">
                                     <option value=""><?= $t['select_user'] ?></option>
-                                    <?php foreach (($iaccUsers ?? []) as $u): ?>
+                                    <?php foreach (($activeUsers ?? []) as $u): ?>
+                                        <?php
+                                        // For partners scope, label with agent company so admins
+                                        // can disambiguate two reps with the same name from
+                                        // different partner agencies.
+                                        if ($scope === 'partners') {
+                                            $companyLabel = $isThai
+                                                ? ($u['agent_company_th'] ?? $u['agent_company_en'] ?? '')
+                                                : ($u['agent_company_en'] ?? $u['agent_company_th'] ?? '');
+                                            $optionLabel = ($u['name'] ?: $u['email']) . ' — ' . $companyLabel;
+                                        } else {
+                                            $optionLabel = ($u['name'] ?: $u['email']) . ' (lvl ' . (int)$u['level'] . ')';
+                                        }
+                                        ?>
                                         <option value="<?= (int)$u['id'] ?>" <?= ($a['linked_user_id'] ?? 0) == $u['id'] ? 'selected' : '' ?>>
-                                            <?= htmlspecialchars(($u['name'] ?: $u['email']) . ' (lvl ' . (int)$u['level'] . ')', ENT_QUOTES, 'UTF-8') ?>
+                                            <?= htmlspecialchars($optionLabel, ENT_QUOTES, 'UTF-8') ?>
                                         </option>
                                     <?php endforeach; ?>
                                 </select>

--- a/app/Views/model/list.php
+++ b/app/Views/model/list.php
@@ -174,6 +174,32 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
                        placeholder="Enter description..." style="min-height:100px;"><?=htmlspecialchars($edit_data['des'] ?? '')?></textarea>
             </div>
         </div>
+        <?php
+            // v6.6 #135 follow-up — LINE catalog visibility toggle.
+            // Defaults to 1 (visible) for new rows; admins uncheck to hide
+            // non-tour models like entrance fees from the customer-facing
+            // carousel triggered by "ดูทัวร์" / "show tours".
+            $_isThai = ($_SESSION['lang'] ?? '0') === '1';
+            $_isCustomerBookable = (int)($edit_data['is_customer_bookable'] ?? 1);
+        ?>
+        <div class="form-row">
+            <div class="form-group" style="width:100%;">
+                <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                    <input type="checkbox" name="is_customer_bookable" value="1"
+                           <?= $_isCustomerBookable === 1 ? 'checked' : '' ?>
+                           style="width:auto; margin:0;">
+                    <span style="font-weight:500;">
+                        <i class="fa fa-line-chart" style="color:#06C755;"></i>
+                        <?= $_isThai ? 'แสดงในรายการทัวร์ LINE OA' : 'Show in LINE OA catalog' ?>
+                    </span>
+                </label>
+                <small class="text-muted" style="display:block; margin-top:4px; margin-left:24px;">
+                    <?= $_isThai
+                        ? 'ติ๊กเพื่อให้ทัวร์นี้แสดงในรายการที่ลูกค้าเห็นเมื่อพิมพ์ "ดูทัวร์" ผ่าน LINE OA — ยกเลิกถ้าเป็นรายการที่ไม่ใช่ทัวร์ (เช่น ค่าเข้าหน้าท่า)'
+                        : 'Check to include this row in the customer-facing carousel triggered by "show tours" / "ดูทัวร์". Uncheck for non-tour items (e.g. entrance fees).' ?>
+                </small>
+            </div>
+        </div>
         <div class="form-actions">
             <input type="hidden" name="method" value="<?=$edit_data ? 'E' : 'A'?>">
             <input type="hidden" name="page" value="mo_list">

--- a/app/Views/model/list.php
+++ b/app/Views/model/list.php
@@ -181,6 +181,7 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
             // carousel triggered by "ดูทัวร์" / "show tours".
             $_isThai = ($_SESSION['lang'] ?? '0') === '1';
             $_isCustomerBookable = (int)($edit_data['is_customer_bookable'] ?? 1);
+            $_parentModelId      = (int)($edit_data['parent_model_id'] ?? 0);
         ?>
         <div class="form-row">
             <div class="form-group" style="width:100%;">
@@ -197,6 +198,27 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
                     <?= $_isThai
                         ? 'ติ๊กเพื่อให้ทัวร์นี้แสดงในรายการที่ลูกค้าเห็นเมื่อพิมพ์ "ดูทัวร์" ผ่าน LINE OA — ยกเลิกถ้าเป็นรายการที่ไม่ใช่ทัวร์ (เช่น ค่าเข้าหน้าท่า)'
                         : 'Check to include this row in the customer-facing carousel triggered by "show tours" / "ดูทัวร์". Uncheck for non-tour items (e.g. entrance fees).' ?>
+                </small>
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group" style="width:100%;">
+                <label>
+                    <i class="fa fa-sitemap"></i>
+                    <?= $_isThai ? 'เป็นรายการย่อยของทัวร์' : 'Sub-item of tour' ?>
+                </label>
+                <select class="form-control" name="parent_model_id">
+                    <option value="0">— <?= $_isThai ? 'รายการหลัก (ไม่ใช่รายการย่อย)' : 'Top-level (not a sub-item)' ?> —</option>
+                    <?php foreach (($parentOptions ?? []) as $p): ?>
+                        <option value="<?= (int)$p['id'] ?>" <?= $_parentModelId === (int)$p['id'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($p['model_name']) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+                <small class="text-muted" style="display:block; margin-top:4px;">
+                    <?= $_isThai
+                        ? 'เลือกทัวร์หลักหากรายการนี้เป็นค่าธรรมเนียมหรือรายการเสริม (เช่น ค่าเข้าหน้าท่าของทัวร์อ่างทอง) — รายการย่อยจะถูกเพิ่มอัตโนมัติเมื่อมีการจองทัวร์หลักผ่าน LINE'
+                        : 'Pick a parent tour if this row is a fee or add-on (e.g. pier fee for the Ang Thong tour). Sub-items are auto-added as line items when the parent tour is booked via LINE.' ?>
                 </small>
             </div>
         </div>
@@ -233,10 +255,24 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
                 $row_num++;
                 $isActive = intval($data['is_active'] ?? 1);
             ?>
+            <?php
+                // v6.6 — sub-models render indented under their parent so the
+                // hierarchy is visible at a glance. The list query orders
+                // by id; if you find sub-models drifting away from their
+                // parents in pagination, switch the controller's
+                // getPaginated to ORDER BY COALESCE(parent_model_id, id), parent_model_id.
+                $_isSubModel = !empty($data['parent_model_id']);
+            ?>
             <tr class="<?=$isActive ? '' : 'row-inactive'?>" id="row-mo_list-<?=$data['id']?>">
                 <td class="text-muted"><?=$row_num?></td>
                 <td>
+                    <?php if ($_isSubModel): ?>
+                        <span style="color:#999; margin-right:6px;">└</span>
+                    <?php endif; ?>
                     <span class="item-name"><?=htmlspecialchars($data['model_name'])?></span>
+                    <?php if ($_isSubModel): ?>
+                        <span class="badge" style="background:#fef3c7; color:#92400e; padding:2px 8px; border-radius:10px; font-size:10px; margin-left:6px;">sub-item</span>
+                    <?php endif; ?>
                     <?php if ($data['des']): ?>
                     <br><small class="item-desc"><?=htmlspecialchars(mb_strimwidth($data['des'], 0, 50, '…'))?></small>
                     <?php endif; ?>

--- a/app/Views/model/list.php
+++ b/app/Views/model/list.php
@@ -210,8 +210,19 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
                 <select class="form-control" name="parent_model_id">
                     <option value="0">— <?= $_isThai ? 'รายการหลัก (ไม่ใช่รายการย่อย)' : 'Top-level (not a sub-item)' ?> —</option>
                     <?php foreach (($parentOptions ?? []) as $p): ?>
+                        <?php
+                            // Show "<model_name> — <description>" so admins recognise
+                            // the tour by name, not just by code.
+                            $_pName = (string)($p['model_name'] ?? '');
+                            $_pDes  = trim(strip_tags((string)($p['des'] ?? '')));
+                            $_pDes  = preg_replace('/\s+/', ' ', $_pDes);
+                            $_pLabel = $_pName;
+                            if ($_pDes !== '') {
+                                $_pLabel .= ' — ' . mb_strimwidth($_pDes, 0, 60, '…');
+                            }
+                        ?>
                         <option value="<?= (int)$p['id'] ?>" <?= $_parentModelId === (int)$p['id'] ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($p['model_name']) ?>
+                            <?= htmlspecialchars($_pLabel) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/database/migrations/2026_05_07_v6_4_133_line_message_templates_catchup.sql
+++ b/database/migrations/2026_05_07_v6_4_133_line_message_templates_catchup.sql
@@ -1,0 +1,55 @@
+-- Migration: 2026_05_07_v6_4_133_line_message_templates_catchup.sql
+-- v6.4 #133 — Catch-up migration for line_message_templates
+--
+-- The v6.2 LINE OA Rich Messaging code references this table
+-- (App\Models\LineMessaging::getTemplates etc.) but no migration file
+-- existed in database/migrations/ to create it. Production DBs already
+-- have it (created out-of-band during the v6.2 deploy); this migration
+-- is a CREATE TABLE IF NOT EXISTS so:
+--   * Local dev DBs get the table for the first time
+--   * New tenant DBs get it on next provision
+--   * Production is unchanged (table already exists, statement is no-op)
+--
+-- The schema mirrors what's currently on production staging
+-- (f2coth_dev) per phpMyAdmin's SHOW COLUMNS output. The enum on
+-- template_type intentionally only includes values we control here;
+-- production may have additional values from the v6.2 deploy and they
+-- are preserved (this migration won't run there).
+--
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+
+CREATE TABLE IF NOT EXISTS `line_message_templates` (
+    `id`             INT(11) NOT NULL AUTO_INCREMENT,
+    `company_id`     INT(11) NOT NULL,
+    `name`           VARCHAR(150) NOT NULL,
+    -- Matches the production enum verified on f2coth_dev 2026-05-07.
+    -- Agent-flow templates are identified by `name` prefix (e.g.
+    -- 'agent.booking_confirmed') with template_type='custom' — see
+    -- LineTemplateRenderer. Adding new enum values here would diverge
+    -- from prod and force a schema change at next deploy.
+    `template_type`  ENUM(
+                        'tour_package',
+                        'quotation',
+                        'booking_confirm',
+                        'payment_reminder',
+                        'voucher',
+                        'custom'
+                     ) DEFAULT 'custom',
+    `message_type`   ENUM('text','flex') DEFAULT 'flex',
+    `alt_text`       VARCHAR(400) DEFAULT NULL,
+    `content_th`     TEXT DEFAULT NULL,
+    `content_en`     TEXT DEFAULT NULL,
+    `variables_json` TEXT DEFAULT NULL
+                     COMMENT 'JSON list of placeholder definitions for the editor UI',
+    `is_active`      TINYINT(1) DEFAULT 1,
+    `created_by`     INT(11) DEFAULT NULL,
+    `created_at`     DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`     DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`     DATETIME DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_lmt_company`        (`company_id`),
+    KEY `idx_lmt_template_type`  (`template_type`),
+    KEY `idx_lmt_is_active`      (`is_active`),
+    KEY `idx_lmt_company_name`   (`company_id`, `name`)
+        COMMENT 'Used by LineTemplateRenderer for per-tenant lookups by template name'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/2026_05_07_v6_6_135_model_is_customer_bookable.sql
+++ b/database/migrations/2026_05_07_v6_6_135_model_is_customer_bookable.sql
@@ -1,0 +1,46 @@
+-- Migration: 2026_05_07_v6_6_135_model_is_customer_bookable.sql
+-- v6.6 #135 follow-up — add is_customer_bookable flag to model
+--
+-- Carousel discovery (#135) shows every active model row, including
+-- non-tour entries like entrance fees that operators don't want
+-- customers booking directly. This flag lets the operator hide
+-- specific models from the LINE OA catalog while keeping them
+-- otherwise active for internal pricing/reporting.
+--
+-- Default = 1 so existing tours stay visible; admin flips specific
+-- rows to 0 for entrance fees and other internal-only models.
+--
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+-- Idempotent via stored-procedure column-existence check
+
+DROP PROCEDURE IF EXISTS _migrate_v66_135_bookable;
+DELIMITER $$
+CREATE PROCEDURE _migrate_v66_135_bookable()
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'model'
+          AND COLUMN_NAME  = 'is_customer_bookable'
+    ) THEN
+        ALTER TABLE `model`
+            ADD COLUMN `is_customer_bookable` TINYINT(1) NOT NULL DEFAULT 1
+            COMMENT 'v6.6 #135 — show this model in LINE OA customer-facing catalog (1=yes, 0=hidden, e.g. entrance fees)';
+    END IF;
+
+    -- Index to keep the LineTourCatalog query fast even on tenants with
+    -- many models. Composite (company_id, is_active, is_customer_bookable)
+    -- matches the WHERE clause exactly.
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'model'
+          AND INDEX_NAME   = 'idx_model_company_active_bookable'
+    ) THEN
+        CREATE INDEX `idx_model_company_active_bookable`
+            ON `model` (`company_id`, `is_active`, `is_customer_bookable`);
+    END IF;
+END$$
+DELIMITER ;
+CALL _migrate_v66_135_bookable();
+DROP PROCEDURE IF EXISTS _migrate_v66_135_bookable;

--- a/database/migrations/2026_05_07_v6_6_model_parent_id_for_submodels.sql
+++ b/database/migrations/2026_05_07_v6_6_model_parent_id_for_submodels.sql
@@ -1,0 +1,44 @@
+-- Migration: 2026_05_07_v6_6_model_parent_id_for_submodels.sql
+-- v6.6 — sub-model relationship via parent_model_id
+--
+-- Lets a model be expressed as a child of another model (e.g. an entrance
+-- fee under a tour). The carousel and customer-facing flows continue to
+-- show only top-level rows (parent_model_id IS NULL); the LINE booking
+-- write path auto-seeds child models as additional line items so admins
+-- don't have to add entrance fees / extras manually for every booking.
+--
+-- Compatible: MySQL 5.7 / MariaDB / cPanel phpMyAdmin (no CLI required)
+-- Idempotent via stored-procedure column-existence check.
+
+DROP PROCEDURE IF EXISTS _migrate_v66_model_parent;
+DELIMITER $$
+CREATE PROCEDURE _migrate_v66_model_parent()
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'model'
+          AND COLUMN_NAME  = 'parent_model_id'
+    ) THEN
+        ALTER TABLE `model`
+            ADD COLUMN `parent_model_id` INT(11) NULL DEFAULT NULL
+            COMMENT 'v6.6 — when set, this model is a sub-item of the parent (e.g. entrance fee under a tour). Auto-seeded as a line item when parent is booked. Top-level models have NULL.';
+    END IF;
+
+    -- Composite index on (parent_model_id, is_active) supports both
+    --   (a) "find children of tour X for auto-seed" (parent_model_id = X)
+    --   (b) "list top-level tours" (parent_model_id IS NULL)
+    -- without a separate index for each.
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'model'
+          AND INDEX_NAME   = 'idx_model_parent_active'
+    ) THEN
+        CREATE INDEX `idx_model_parent_active`
+            ON `model` (`parent_model_id`, `is_active`);
+    END IF;
+END$$
+DELIMITER ;
+CALL _migrate_v66_model_parent();
+DROP PROCEDURE IF EXISTS _migrate_v66_model_parent;

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -293,11 +293,19 @@ function handlePostback(array $event, int $companyId, int $dbUserId, \App\Models
             // template scoped to the tenant; defensive against postback
             // tampering via the tenancy filter in fetchTour().
             $tourId = intval($params['tour_id'] ?? 0);
-            // Use the LINE user's last inbound message language as a hint
-            // for the reply language; default EN for postbacks (button
-            // taps don't carry text).
-            $lineUser = $model->getLineUserById($dbUserId);
-            $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+            // Language is carried in the postback data (set by the
+            // carousel that produced the button), so the prefill reply
+            // matches the user's original message language. Falls back
+            // to the LINE display_name regex only when lang is missing —
+            // unreliable for Thai users with English-spelled names but
+            // a reasonable last resort for legacy carousels.
+            $postbackLang = (string)($params['lang'] ?? '');
+            if ($postbackLang === 'th' || $postbackLang === 'en') {
+                $lang = $postbackLang;
+            } else {
+                $lineUser = $model->getLineUserById($dbUserId);
+                $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+            }
             $reply = \App\Services\LineTourCatalog::buildPrefillReply($companyId, $tourId, $lang);
             if ($reply) {
                 $service->replyMessage($replyToken, [$reply]);

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -314,44 +314,23 @@ function handleOrderCommand(string $replyToken, int $companyId, int $dbUserId, s
 
 function handleBookingCommand(string $replyToken, int $companyId, int $dbUserId, string $bookingText, \App\Models\LineOA $model, \App\Services\LineService $service): void
 {
-    // Parse booking: "2026-04-15 14:00" or "15 Apr 2pm"
-    $bookingDate = null;
-    $bookingTime = null;
+    // v6.6 #134 — deprecated path. The legacy `book/จอง <date> <time>` flow
+    // was useful before tour-context booking shipped, but it can't capture
+    // *which tour* the customer wants — the operator had to follow up
+    // manually. Now that the structured template is open to direct customers
+    // (not just bound agents), redirect users to that flow instead of
+    // writing a vague row to line_orders.
+    //
+    // Existing line_orders rows are preserved; we just stop creating new
+    // ones from this entry point.
+    $lineUser    = $model->getLineUserById($dbUserId);
+    $lang        = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', $bookingText) ? 'th' : 'en';
+    $redirectMsg = $lang === 'th'
+        ? "กรุณาใช้แบบฟอร์มการจองใหม่ — พิมพ์ \"จองทัวร์\" พร้อมรายละเอียด เช่น:\n\nจองทัวร์\nทัวร์: <ชื่อทัวร์>\nวันที่: " . ($_POST['date'] ?? date('Y-m-d', strtotime('+7 days'))) . "\nผู้ใหญ่: <จำนวน>\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>"
+        : "Please use the new booking template — start your message with \"book tour\" and include the tour details, e.g.:\n\nbook tour\ntour: <tour name>\ndate: " . date('Y-m-d', strtotime('+7 days')) . "\nadults: <count>\ncustomer: <name>\nmobile: <phone>";
 
-    // Try standard format first
-    if (preg_match('/(\d{4}-\d{2}-\d{2})\s+(\d{1,2}:\d{2})/', $bookingText, $m)) {
-        $bookingDate = $m[1];
-        $bookingTime = $m[2];
-    } else {
-        // Try to parse naturally
-        $ts = strtotime($bookingText);
-        if ($ts && $ts > time()) {
-            $bookingDate = date('Y-m-d', $ts);
-            $bookingTime = date('H:i', $ts);
-        }
-    }
-
-    if (!$bookingDate) {
-        $service->replyText($replyToken, "Please provide a valid date and time.\nFormat: book 2026-04-15 14:00");
-        return;
-    }
-
-    $lineUser = $model->getLineUserById($dbUserId);
-    $orderId = $model->createOrder($companyId, $dbUserId, [
-        'order_type' => 'booking',
-        'guest_name' => $lineUser['display_name'] ?? '',
-        'booking_date' => $bookingDate,
-        'booking_time' => $bookingTime
-    ]);
-
-    $order = $model->getOrder($orderId, $companyId);
-    $orderRef = $order['order_ref'] ?? 'LINE-BOOKING';
-
-    $flex = $service->buildBookingFlex($orderRef, $bookingDate, $bookingTime, $lineUser['display_name'] ?? '');
-    $service->replyMessage($replyToken, [
-        ['type' => 'flex', 'altText' => 'Booking ' . $orderRef, 'contents' => $flex]
-    ]);
-    $model->logMessage($companyId, $dbUserId, 'outbound', 'flex', null, null, 'Booking created: ' . $orderRef);
+    $service->replyText($replyToken, $redirectMsg);
+    $model->logMessage($companyId, $dbUserId, 'outbound', 'text', null, null, '[v6.6 #134 redirect: legacy book→template] ' . substr($redirectMsg, 0, 80));
 }
 
 function handleStatusCommand(string $replyToken, int $companyId, int $dbUserId, string $orderRef, \App\Models\LineOA $model, \App\Services\LineService $service): void

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -293,18 +293,25 @@ function handlePostback(array $event, int $companyId, int $dbUserId, \App\Models
             // template scoped to the tenant; defensive against postback
             // tampering via the tenancy filter in fetchTour().
             $tourId = intval($params['tour_id'] ?? 0);
-            // Language is carried in the postback data (set by the
-            // carousel that produced the button), so the prefill reply
-            // matches the user's original message language. Falls back
-            // to the LINE display_name regex only when lang is missing —
-            // unreliable for Thai users with English-spelled names but
-            // a reasonable last resort for legacy carousels.
+            // Language resolution priority:
+            //   1. $params['lang'] from the postback data (set by the
+            //      carousel in v6.6 #150) — authoritative if present.
+            //   2. The user's most recent inbound text message — reliable
+            //      since the carousel-trigger message is always more
+            //      recent than the bubble being tapped. Catches legacy
+            //      carousels rendered before #150.
+            //   3. display_name regex — last resort. Unreliable for Thai
+            //      users with English-spelled names ("Sinthorn") but
+            //      better than nothing for users with no text history.
             $postbackLang = (string)($params['lang'] ?? '');
             if ($postbackLang === 'th' || $postbackLang === 'en') {
                 $lang = $postbackLang;
             } else {
-                $lineUser = $model->getLineUserById($dbUserId);
-                $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+                $lang = $model->getRecentLanguage($companyId, $dbUserId);
+                if ($lang === null) {
+                    $lineUser = $model->getLineUserById($dbUserId);
+                    $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+                }
             }
             $reply = \App\Services\LineTourCatalog::buildPrefillReply($companyId, $tourId, $lang);
             if ($reply) {

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -325,9 +325,14 @@ function handleBookingCommand(string $replyToken, int $companyId, int $dbUserId,
     // ones from this entry point.
     $lineUser    = $model->getLineUserById($dbUserId);
     $lang        = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', $bookingText) ? 'th' : 'en';
-    $redirectMsg = $lang === 'th'
-        ? "กรุณาใช้แบบฟอร์มการจองใหม่ — พิมพ์ \"จองทัวร์\" พร้อมรายละเอียด เช่น:\n\nจองทัวร์\nทัวร์: <ชื่อทัวร์>\nวันที่: " . ($_POST['date'] ?? date('Y-m-d', strtotime('+7 days'))) . "\nผู้ใหญ่: <จำนวน>\nลูกค้า: <ชื่อ>\nมือถือ: <เบอร์>"
-        : "Please use the new booking template — start your message with \"book tour\" and include the tour details, e.g.:\n\nbook tour\ntour: <tour name>\ndate: " . date('Y-m-d', strtotime('+7 days')) . "\nadults: <count>\ncustomer: <name>\nmobile: <phone>";
+    // Renderer routes through line_message_templates (#133) so admins can
+    // customize the wording per tenant — falls back to a hardcoded default
+    // when no override exists. {{sample_date}} suggests a realistic future
+    // travel date so the user isn't tempted to copy-paste a stale value.
+    $redirectMsg = \App\Services\LineTemplateRenderer::renderText(
+        $companyId, 'legacy.book_redirect', $lang,
+        ['sample_date' => date('Y-m-d', strtotime('+7 days'))]
+    );
 
     $service->replyText($replyToken, $redirectMsg);
     $model->logMessage($companyId, $dbUserId, 'outbound', 'text', null, null, '[v6.6 #134 redirect: legacy book→template] ' . substr($redirectMsg, 0, 80));

--- a/line-webhook.php
+++ b/line-webhook.php
@@ -190,6 +190,20 @@ function handleMessage(array $event, int $companyId, int $dbUserId, \App\Models\
         // Check for order keywords
         $lowerContent = mb_strtolower($content);
 
+        // v6.6 #135 — Tour catalog browse trigger. Cheaper check than the
+        // booking parser, so run it first. Triggers on bilingual phrases
+        // like "ดูทัวร์" / "show tours" / "tour list". Doesn't overlap with
+        // the booking template's "จองทัวร์" / "book tour" triggers.
+        if (\App\Services\LineTourCatalog::isTriggered($content)) {
+            $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', $content) ? 'th' : 'en';
+            $carousel = \App\Services\LineTourCatalog::buildCarousel($companyId, $lang);
+            $service->replyMessage($replyToken, [$carousel]);
+            $msgType    = $carousel['type'] ?? 'text';
+            $msgContent = $msgType === 'text' ? ($carousel['text'] ?? '') : json_encode($carousel);
+            $model->logMessage($companyId, $dbUserId, 'outbound', $msgType, null, null, '[v6.6 #135 tour catalog] ' . substr($msgContent, 0, 80));
+            return;
+        }
+
         // v6.3 #120 — Agent text-template booking (intercept before legacy commands).
         // ingestText() returns handled=false when no booking trigger, so we fall
         // through to the existing order/book/status/auto-reply chain.
@@ -271,6 +285,30 @@ function handlePostback(array $event, int $companyId, int $dbUserId, \App\Models
         case 'cancel_order':
             $orderRef = $params['ref'] ?? '';
             $service->replyText($replyToken, "Order {$orderRef} has been cancelled. ❌");
+            break;
+
+        case 'prefill_booking':
+            // v6.6 #135 — fired when a user taps "Book this" on a tour
+            // bubble in the catalog carousel. Send back a pre-filled
+            // template scoped to the tenant; defensive against postback
+            // tampering via the tenancy filter in fetchTour().
+            $tourId = intval($params['tour_id'] ?? 0);
+            // Use the LINE user's last inbound message language as a hint
+            // for the reply language; default EN for postbacks (button
+            // taps don't carry text).
+            $lineUser = $model->getLineUserById($dbUserId);
+            $lang = (bool)preg_match('/[\x{0E00}-\x{0E7F}]/u', (string)($lineUser['display_name'] ?? '')) ? 'th' : 'en';
+            $reply = \App\Services\LineTourCatalog::buildPrefillReply($companyId, $tourId, $lang);
+            if ($reply) {
+                $service->replyMessage($replyToken, [$reply]);
+                $msgContent = $reply['type'] === 'text' ? ($reply['text'] ?? '') : json_encode($reply);
+                $model->logMessage($companyId, $dbUserId, 'outbound', $reply['type'] ?? 'text', null, null, '[v6.6 #135 prefill] ' . substr($msgContent, 0, 80));
+            } else {
+                // Unknown tour id (or tampered postback). Quiet fallback.
+                $service->replyText($replyToken, $lang === 'th'
+                    ? 'ไม่พบทัวร์ที่เลือก กรุณาลองอีกครั้ง'
+                    : 'Tour not found. Please try again.');
+            }
             break;
 
         default:


### PR DESCRIPTION
# v6.6 production release — Customer-Direct LINE Booking + Auto-Seed Items + Sub-Models

Promotes `develop` → `main`. Bundles 10 PRs landed on staging since the v6.3 release. Every PR has been individually CI-greened and staged-tested.

## Headline

LINE OA bookings now go end-to-end with **zero manual admin steps** in the common case:

- Anyone (agent or direct customer) can browse the tour catalog inside LINE (`ดูทัวร์` / `show tours`)
- Tap **"Book this"** on a tour → bot returns a pre-filled template
- Customer fills in date / pax / contact info → sends back
- Booking lands in `tour_bookings` with **auto-seeded line items** (parent tour + linked entrance fees / sub-models), grand total computed, customer contact captured to `tour_booking_contacts`, nationality detected for correct entrance-fee pricing, and `agent_id` auto-resolved if the LINE user is bound to a partner-tenant employee.

## What ships (10 PRs, by theme)

### Booking-flow expansion

| PR | What |
|---|---|
| **#140** | `#136` — Extend LINE bindings to agent-tenant users; auto-resolve `tour_bookings.agent_id` from binding for partner-agent commission attribution |
| **#142** | `#134` — Open the structured booking template to direct customers (no longer requires `user_type='agent'` binding); deprecate v6.2 `book <date> <time>` flow with a redirect to the new template |
| **#148** | Sub-models (`model.parent_model_id`) + nationality detection (explicit `สัญชาติ:` field + Thai-script heuristic) + auto-seed of `tour_booking_items` rows for the parent tour and any sub-models, with booking subtotal/total recomputed; folded #147 (description in remark) in |
| **#149** | Empty trigger (`จองทัวร์` / `book tour` alone) returns the tour carousel instead of "missing fields" Flex; parent dropdown on model admin shows description |

### Discoverability

| PR | What |
|---|---|
| **#144** | `#135` — Flex carousel of available tours; postback "Book this" returns pre-filled template; `LineTourCatalog` service |
| **#145** | `model.is_customer_bookable` flag + carousel filter; expanded prefill template with all parser fields |
| **#146** | UI checkbox on the model admin form for `is_customer_bookable` (replaces SQL workaround) |

### Localization correctness

| PR | What |
|---|---|
| **#150** | Carousel postback button data carries `lang=th\|en` so the Book-tap reply matches the user's browse language |
| **#151** | Postback prefill resolution chain — `$params['lang']` → most-recent inbound message language → display_name regex (last resort). Catches legacy carousels rendered before #150. |

### Self-serve customization

| PR | What |
|---|---|
| **#143** | `#133 Phase 1` — `LineTemplateRenderer` service + `line_message_templates` catch-up migration; plain-text replies (tour_not_found, tour_ambiguous, write_failed, legacy book redirect) now per-tenant customizable via the existing template editor UI; hardcoded defaults stay as fallbacks |

## Schema migrations

Run on production phpMyAdmin **after the merge auto-deploys the file changes**. Both are idempotent (stored-procedure column-existence checks) — safe to re-run, safe to deploy in any order relative to the file deploy.

1. `database/migrations/2026_05_07_v6_4_133_line_message_templates_catchup.sql` — `CREATE TABLE IF NOT EXISTS line_message_templates`. **Likely a no-op on prod** (table already exists from v6.2 LINE OA Rich Messaging deploy) but ensures the schema is reproducible from migrations.
2. `database/migrations/2026_05_07_v6_6_135_model_is_customer_bookable.sql` — adds `model.is_customer_bookable` + composite index.
3. `database/migrations/2026_05_07_v6_6_model_parent_id_for_submodels.sql` — adds `model.parent_model_id` + composite index.

**Verify after running:**

```sql
SHOW COLUMNS FROM line_message_templates LIKE 'template_type';
SHOW COLUMNS FROM model LIKE 'is_customer_bookable';
SHOW COLUMNS FROM model LIKE 'parent_model_id';
SHOW INDEX  FROM model WHERE Key_name = 'idx_model_company_active_bookable';
SHOW INDEX  FROM model WHERE Key_name = 'idx_model_parent_active';
```

All five should return rows.

## Production smoke test (post-deploy)

1. Send `ดูทัวร์` from any LINE account → carousel with 📝 จองทัวร์นี้ buttons
2. Tap any tour's Book button → pre-filled Thai template comes back with `tour:` populated
3. Complete the template (fill date / pax / customer / mobile, optionally email / hotel / room / `สัญชาติ:`) and send back → ✅ green Flex with `BK-YYMMDD-NNN`
4. Open the booking detail in iACC admin (`index.php?page=tour_booking_view&id=<X>`):
   - **Customer:** matches the typed `ลูกค้า:` value
   - **Booking By:** the bound iACC user's name (or `<LINE display> [LINE customer]` if non-bound)
   - **Hotel / Room:** populated from `ที่พัก:` / `หมายเลขห้อง:` if you typed them
   - **Items section:** auto-seeded with the tour line + any linked sub-model entrance fees, qty/price split by Thai/Foreigner per resolved nationality
   - **Grand Total:** non-zero, sum of items
   - **Remark:** includes `[from LINE agent text]` + `Tour: <code> | <description>` + `Nationality: <value> (specified by sender)` or `(auto-detected from name script — please verify)`
5. Verify `tour_booking_contacts` child row populated with name, mobile, email, messenger, nationality

## Operator setup steps after deploy (one-time)

For each tenant that has entrance fees or extras as separate `model` rows, link them to their parent tour so auto-seed can fire:

- Open `index.php?page=mo_list` → edit each entrance-fee model → set "Sub-item of tour" dropdown to the parent tour → save

After this, every LINE booking for that parent tour will auto-include the entrance fee as a line item, with prices defaulting to `model.price` and qty split by nationality.

## Backlog (not in this release)

- **#133 Phase 2** — template the success/error Flex bubbles (currently hardcoded; admins can't customize Flex copy yet)
- Marketing dashboard for `tour_booking_contacts.nationality` (top source countries, bookings missing country)
- Bulk-toggle UI for `is_customer_bookable` on the model admin
- Auto-suspend LINE bindings when partner contract expires (from #136 spec, deferred)
- Indented sub-model pagination ordering on `mo_list` (children can drift across pages)

## Rollback plan

If anything goes sideways post-deploy, the release PR can be reverted via `git revert <merge-commit>` on `main`. Migrations don't need to be reverted — both new columns are nullable / default-safe and the table catch-up is `CREATE IF NOT EXISTS` (no-op on prod). Existing rows continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
